### PR TITLE
feat(apps/web): move app drawer buttons to app bar

### DIFF
--- a/apps/web/src/components/app/AppBar/buttons/CommandListButton.tsx
+++ b/apps/web/src/components/app/AppBar/buttons/CommandListButton.tsx
@@ -1,0 +1,25 @@
+import { IconButton, Typography } from "@mui/material";
+import Link from "next/link";
+import { SiDiscord } from "react-icons/si";
+import { BootstrapTooltip } from "src/components/Tooltip";
+import { env } from "../../../../env/client.mjs";
+import { BsListNested } from "react-icons/bs";
+const CommandListButton = () => {
+  return (
+    <BootstrapTooltip title="Command List Page">
+      <Typography>
+        <Link href="/app/command-list" passHref>
+          <IconButton
+            aria-label="command list page"
+            sx={{
+              display: "flex",
+            }}>
+            <BsListNested />
+          </IconButton>
+        </Link>
+      </Typography>
+    </BootstrapTooltip>
+  );
+};
+
+export default CommandListButton;

--- a/apps/web/src/components/app/AppBar/index.tsx
+++ b/apps/web/src/components/app/AppBar/index.tsx
@@ -7,11 +7,14 @@ import AccountMenu from "../AccountMenu";
 import AppBarTitle from "../../common/AppBarTitle";
 import AppBarButton from "./AppBarButton";
 import MinimizeIcon from "@mui/icons-material/Minimize";
-import DrawerButton from "./buttons/DrawerButton";
+
 import { useState } from "react";
-import AppDrawer from "../AppDrawer";
+
 import { FC } from "react";
 import GetTwitchBotButton from "./buttons/GetTwitchBotButton";
+
+import GetDiscordBotButton from "./buttons/GetDiscordBotButton";
+import CommandListButton from "./buttons/CommandListButton";
 
 type IResponsiveAppBarProps = {
   isDrawerOpen: boolean;
@@ -42,10 +45,6 @@ const ResponsiveAppBar: FC<IResponsiveAppBarProps> = ({
 
   return (
     <>
-      <AppDrawer
-        isDrawerOpen={drawerIsOpen}
-        drawerHandler={() => setDrawerIsOpen(!drawerIsOpen)}
-      />
       <AppBar
         position="fixed"
         color="transparent"
@@ -65,8 +64,10 @@ const ResponsiveAppBar: FC<IResponsiveAppBarProps> = ({
               drawerHandler={drawerHandler}>
               <MinimizeIcon />
             </AppBarButton>
-            <DrawerButton onClick={() => setDrawerIsOpen(!drawerIsOpen)} />
+
             <GetTwitchBotButton />
+            <GetDiscordBotButton />
+            <CommandListButton />
             <Box sx={{ flexGrow: 1, display: { xs: "none", md: "flex" } }} />
             <Link href={interfaceURL}>
               <IconButton


### PR DESCRIPTION
![image](https://github.com/senchabot-opensource/monorepo/assets/121015513/7d2733d8-3fcd-4a98-8a2c-cda1143514d4)


closes #357 