### PR TITLE
feat(apps/web): perform data fetching with useEffect with useQuery

### DIFF
--- a/apps/web/src/components/auth/LinkAccount.tsx
+++ b/apps/web/src/components/auth/LinkAccount.tsx
@@ -7,9 +7,11 @@ import {
 } from "@mui/material";
 import { SiDiscord, SiTwitch } from "react-icons/si";
 import { signIn } from "next-auth/react";
-import { FC, ReactNode, useEffect, useState } from "react";
+import { FC, ReactNode } from "react";
 import { getAccount } from "src/api";
 import { IAccount } from "src/types";
+import { useQuery } from "@tanstack/react-query";
+import { log } from "console";
 
 type IProps = {
   accountType: "discord" | "twitch";
@@ -18,18 +20,13 @@ type IProps = {
 };
 
 const LinkAccount: FC<IProps> = ({ accountType, accountTitle, icon }) => {
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [accounts, setAccounts] = useState<IAccount[]>([]);
-
-  useEffect(() => {
-    getAccount().then(res => {
-      if (!res.data) return;
-      setAccounts(res.data);
-      setIsLoading(false);
-    });
-  }, [isLoading]);
-
-  const currentProviders = accounts?.map(
+  const { data: accounts, isLoading } = useQuery({
+    queryKey: ["accounts"],
+    queryFn: () => {
+      return getAccount();
+    },
+  });
+  const currentProviders = accounts?.data?.map(
     (account: IAccount) => account.provider,
   );
 


### PR DESCRIPTION
Data fetching was done with useEffect and useQuery.

Before:
```typescript
 const [isLoading, setIsLoading] = useState<boolean>(true);
  const [accounts, setAccounts] = useState<IAccount[]>([]);

  useEffect(() => {
    getAccount().then(res => {
      if (!res.data) return;
      setAccounts(res.data);
      setIsLoading(false);
    });
  }, [isLoading]);
  const currentProviders = accounts?.data?.map(
    (account: IAccount) => account.provider,
  );
```

After:
```typescript
 const { data: accounts, isLoading } = useQuery({
    queryKey: ["accounts"],
    queryFn: () => {
      return getAccount();
    },
  });
  const currentProviders = accounts?.data?.map(
    (account: IAccount) => account.provider,
  );
```