### PR TITLE
fix(discord-bot): modify ParseTwitchUsernameURLParam to return empty …

### DIFF
--- a/apps/discord-bot/internal/service/event/event.go
+++ b/apps/discord-bot/internal/service/event/event.go
@@ -71,9 +71,13 @@ func (es *EventService) CheckLiveStreamScheduledEvents(dS *discordgo.Session) {
 					}
 
 					twitchUsername := helper.ParseTwitchUsernameURLParam(e.EntityMetadata.Location)
+					if twitchUsername == "" {
+						continue
+					}
+
 					isLive, streamTitle, err := es.twitchService.CheckStreamStatus(twitchUsername)
 					if err != nil {
-						log.Printf("[EventService.CheckLiveStreamScheduledEvents] CheckStreamStatus error for %s: %v", twitchUsername, err)
+						log.Printf("[EventService.CheckLiveStreamScheduledEvents] CheckStreamStatus error in GuildID: %s for the streamer: %s Error: %v", e.GuildID, twitchUsername, err)
 						continue
 					}
 

--- a/helper/helpers.go
+++ b/helper/helpers.go
@@ -193,7 +193,7 @@ func ParseTwitchUsernameURLParam(str string) string {
 		return matches[1]
 	}
 
-	return str
+	return ""
 }
 
 func ParseCustomAPIURLFromMessage(message string) (string, int, int, bool) {

--- a/pkg/twitchapi/twitch.go
+++ b/pkg/twitchapi/twitch.go
@@ -29,6 +29,10 @@ func (s *service) doRequest(method string, path string, token string) (*http.Res
 }
 
 func (s *service) getUserInfo(query string, userIdOrName string) (*model.TwitchUserInfo, error) {
+	if userIdOrName == "" {
+		return nil, errors.New("[twitchapi.getUserInfo] userIdOrName is empty")
+	}
+
 	resp, err := s.doRequest("GET", fmt.Sprintf("/users?%s=%s", query, userIdOrName), s.accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("[twitchapi.getUserInfo] failed to get user info: %w", err)
@@ -131,6 +135,10 @@ func (s *service) GiveShoutout(streamerUsername string, broadcasterId string, me
 }
 
 func (s *service) CheckStreamStatus(username string) (bool, string, error) {
+	if username == "" {
+		return false, "", errors.New("[twitchapi.CheckStreamStatus] username is empty")
+	}
+
 	resp, err := s.doRequest("GET", fmt.Sprintf("/streams?user_login=%s", username), s.accessToken)
 	if err != nil {
 		return false, "", fmt.Errorf("[twitchapi.CheckStreamStatus] failed to check stream status: %w", err)


### PR DESCRIPTION
…string for non-matches