### PR TITLE
feat(extensions): make platform easier to spot in chat widget

### DIFF
--- a/apps/extensions/src/lib/i18n/en.ts
+++ b/apps/extensions/src/lib/i18n/en.ts
@@ -94,6 +94,8 @@ export const en = {
     backgroundOpacity: 'Background Opacity',
     messageBackgroundBox: 'Message Background Box',
     messageBackgroundHint: 'Each message gets its own bordered background box.',
+    platformAccent: 'Platform Color Stripe',
+    platformAccentHint: 'A Twitch purple or Kick green stripe on the left shows where each message came from.',
     boldUsernames: 'Bold Usernames',
     boldMessages: 'Bold Messages',
     previewTitle: 'Widget Preview (Chat Box)',

--- a/apps/extensions/src/lib/i18n/tr.ts
+++ b/apps/extensions/src/lib/i18n/tr.ts
@@ -96,6 +96,9 @@ export const tr: typeof en = {
     backgroundOpacity: 'Arka Plan Saydamlığı',
     messageBackgroundBox: 'Mesaj Arka Plan Kutusu',
     messageBackgroundHint: 'Her mesaj kendi çerçeveli arka plan kutusunu alır.',
+    platformAccent: 'Platform Renk Şeridi',
+    platformAccentHint:
+      'Her mesajın solundaki Twitch moru ya da Kick yeşili şerit, mesajın nereden geldiğini gösterir.',
     boldUsernames: 'Kalın Kullanıcı Adları',
     boldMessages: 'Kalın Mesajlar',
     previewTitle: 'Widget Önizleme (Sohbet Kutusu)',

--- a/apps/extensions/src/routes/setup/chat-widget.tsx
+++ b/apps/extensions/src/routes/setup/chat-widget.tsx
@@ -112,6 +112,7 @@ function ChatWidgetSetup() {
   const [fontSize, setFontSize] = useState("18");
   const [hasBackground, setHasBackground] = useState(false);
   const [itemBackground, setItemBackground] = useState(false);
+  const [platformAccent, setPlatformAccent] = useState(false);
   const [boldUsernames, setBoldUsernames] = useState(false);
   const [boldMessages, setBoldMessages] = useState(false);
   const [backgroundOpacity, setBackgroundOpacity] = useState("0.5");
@@ -162,6 +163,7 @@ function ChatWidgetSetup() {
       if (backgroundOpacity !== "0.5") params.append("bgOpacity", backgroundOpacity);
     }
     if (itemBackground) params.append("itemBackground", "true");
+    if (platformAccent) params.append("platformAccent", "true");
     if (boldUsernames) params.append("boldUsernames", "true");
     if (boldMessages) params.append("boldMessages", "true");
     if (orientation !== "vertical") params.append("orientation", orientation);
@@ -186,6 +188,7 @@ function ChatWidgetSetup() {
     hasBackground,
     backgroundOpacity,
     itemBackground,
+    platformAccent,
     boldUsernames,
     boldMessages,
     orientation,
@@ -213,6 +216,7 @@ function ChatWidgetSetup() {
       if (backgroundOpacity !== "0.5") params.append("bgOpacity", backgroundOpacity);
     }
     if (itemBackground) params.append("itemBackground", "true");
+    if (platformAccent) params.append("platformAccent", "true");
     if (boldUsernames) params.append("boldUsernames", "true");
     if (boldMessages) params.append("boldMessages", "true");
     if (orientation !== "vertical") params.append("orientation", orientation);
@@ -235,6 +239,7 @@ function ChatWidgetSetup() {
     hasBackground,
     backgroundOpacity,
     itemBackground,
+    platformAccent,
     boldUsernames,
     boldMessages,
     orientation,
@@ -578,6 +583,21 @@ function ChatWidgetSetup() {
                 </label>
                 <p className="mt-1 text-xs text-zinc-500">
                   {t("chatWidget.messageBackgroundHint")}
+                </p>
+              </div>
+
+              <div>
+                <label className="flex items-center space-x-2 text-zinc-900 cursor-pointer dark:text-white">
+                  <input
+                    type="checkbox"
+                    checked={platformAccent}
+                    onChange={(e) => setPlatformAccent(e.target.checked)}
+                    className="rounded border-zinc-300 bg-zinc-100 text-green-500 focus:ring-green-500 dark:border-zinc-700 dark:bg-zinc-800"
+                  />
+                  <span className="text-sm">{t("chatWidget.platformAccent")}</span>
+                </label>
+                <p className="mt-1 text-xs text-zinc-500">
+                  {t("chatWidget.platformAccentHint")}
                 </p>
               </div>
 

--- a/apps/extensions/src/routes/widgets/chat-widget.tsx
+++ b/apps/extensions/src/routes/widgets/chat-widget.tsx
@@ -147,6 +147,7 @@ const searchSchema = z.object({
   boldUsernames: z.coerce.boolean().optional(),
   boldMessages: z.coerce.boolean().optional(),
   bgOpacity: z.coerce.number().min(0).max(1).optional().default(0.5),
+  platformAccent: z.coerce.boolean().optional(),
   orientation: z.enum(['vertical', 'horizontal']).optional().default('vertical'),
   platformDisplay: z.enum(['name', 'icon']).optional().default('icon'),
   timestamp: z.coerce.boolean().optional(),
@@ -236,6 +237,11 @@ const ANIMATION_MESSAGE_CLASSES: Record<AnimationChoice, string> = {
   none: '',
 };
 
+const PLATFORM_COLORS: Record<'twitch' | 'kick', string> = {
+  twitch: '#9146FF',
+  kick: '#53FC18',
+};
+
 const GOOGLE_FONTS_LINK_ID = 'chat-widget-google-fonts';
 const GOOGLE_FONTS_PRECONNECT_ID = 'chat-widget-google-fonts-preconnect';
 
@@ -282,7 +288,7 @@ function TwitchIcon({ className, ...props }: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      className={`inline-block h-[1em] w-[1em] ${className ?? ''}`}
+      className={`inline-block h-[1.15em] w-[1.15em] ${className ?? ''}`}
       viewBox="0 0 24 24"
       {...props}
     >
@@ -300,7 +306,7 @@ function KickIcon({ className, ...props }: React.SVGProps<SVGSVGElement>) {
       role="img"
       viewBox="0 0 24 24"
       fill="currentColor"
-      className={`inline-block h-[1em] w-[1em] ${className ?? ''}`}
+      className={`inline-block h-[1.15em] w-[1.15em] ${className ?? ''}`}
       {...props}
     >
       <title>Kick</title>
@@ -603,6 +609,7 @@ function RouteComponent() {
           hasBackground={Boolean(search.background)}
           itemBackground={Boolean(search.itemBackground)}
           bgOpacity={search.bgOpacity}
+          platformAccent={Boolean(search.platformAccent)}
           boldUsernames={Boolean(search.boldUsernames)}
           boldMessages={Boolean(search.boldMessages)}
         />
@@ -629,6 +636,7 @@ type MessageRowProps = {
   hasBackground: boolean;
   itemBackground: boolean;
   bgOpacity: number;
+  platformAccent: boolean;
   boldUsernames: boolean;
   boldMessages: boolean;
 };
@@ -648,6 +656,7 @@ const MessageRow = React.memo(function MessageRow({
   hasBackground,
   itemBackground,
   bgOpacity,
+  platformAccent,
   boldUsernames,
   boldMessages,
 }: MessageRowProps) {
@@ -662,6 +671,14 @@ const MessageRow = React.memo(function MessageRow({
   const itemBgStyle: React.CSSProperties | undefined = itemBackground
     ? { backgroundColor: `rgba(0, 0, 0, ${bgOpacity})` }
     : undefined;
+  // Card and item-background boxes already have horizontal padding; plain rows need room for the stripe.
+  const wrapperStyle: React.CSSProperties | undefined = platformAccent
+    ? {
+        ...itemBgStyle,
+        borderLeft: `2px solid ${PLATFORM_COLORS[msg.platform]}`,
+        paddingLeft: itemBackground || layout === 'card' ? undefined : '0.5em',
+      }
+    : itemBgStyle;
   const accessibleColor = React.useMemo(
     () => getAccessibleColor(msg.color, true) || msg.color || 'unset',
     [msg.color],
@@ -756,7 +773,7 @@ const MessageRow = React.memo(function MessageRow({
   return (
     <div
       className={`${classes.wrapper} ${itemBgClass} ${animClass} transform-gpu ${orientation === 'horizontal' ? 'flex-shrink-0' : ''}`}
-      style={itemBgStyle}
+      style={wrapperStyle}
     >
       {isInlineOrCompact ? (
         <>


### PR DESCRIPTION
When Twitch and Kick chat are merged, it's hard to tell at a glance which platform a message came from.

- Platform icons are slightly larger (1em to 1.15em).
- New optional "Platform Color Stripe" setting (`platformAccent=true`) adds a 2px left border in the platform's brand color (Twitch #9146FF, Kick #53FC18) to each message. Works with all layouts and with the message background box. Off by default, so existing widget URLs look the same apart from the icon size.
- tr/en translations for the new setting.