### PR TITLE
feat(extensions): smoother chat widget animations, typewriter mode and chat-rate aware timing

### DIFF
--- a/apps/extensions/llms.txt
+++ b/apps/extensions/llms.txt
@@ -127,7 +127,7 @@ A customizable multi-chat widget and stream chat box overlay that merges Twitch 
   - `stacked`: Username header displayed above message body.
   - `card`: Message displayed in modern bubble/card format.
   - `compact`: Dense, Twitch-native spacing for high-velocity chats.
-- **Entry Animations (`animation`)**: `slide` (from right), `pop` (scale-in), `bounce`, `stagger`, `fade`, `typing` (letter by letter), and `none`.
+- **Entry Animations (`animation`)**: `slide` (from right), `smooth` (smoother slide, older messages glide up), `pop` (scale-in), `bounce`, `stagger`, `fade`, `typing` (letter by letter), and `none`.
 - **Typography (`font`)**: Selectable fonts including `inter`, `roboto`, `nunito`, `mono` (JetBrains Mono), `serif` (Source Serif 4), and `system`.
 - **Styling Options**:
   - `fontSize`: Pixel font size (default: 18px).
@@ -144,7 +144,7 @@ A customizable multi-chat widget and stream chat box overlay that merges Twitch 
   - `sevenTv` (`true` | `false`), `badges` (`true` | `false`)
   - `fontSize` (number), `font` (`inter` | `roboto` | `nunito` | `mono` | `serif` | `system`)
   - `layout` (`inline` | `stacked` | `card` | `compact`)
-  - `animation` (`slide` | `pop` | `bounce` | `stagger` | `fade` | `typing` | `none`)
+  - `animation` (`slide` | `smooth` | `pop` | `bounce` | `stagger` | `fade` | `typing` | `none`)
   - `background` (`true` | `false`), `bgOpacity` (string: 0.0 - 1.0)
   - `itemBackground` (`true` | `false`)
   - `boldUsernames` (`true` | `false`), `boldMessages` (`true` | `false`)

--- a/apps/extensions/llms.txt
+++ b/apps/extensions/llms.txt
@@ -127,7 +127,7 @@ A customizable multi-chat widget and stream chat box overlay that merges Twitch 
   - `stacked`: Username header displayed above message body.
   - `card`: Message displayed in modern bubble/card format.
   - `compact`: Dense, Twitch-native spacing for high-velocity chats.
-- **Entry Animations (`animation`)**: `slide` (from right), `pop` (scale-in), `bounce`, `stagger`, `fade`, and `none`.
+- **Entry Animations (`animation`)**: `slide` (from right), `pop` (scale-in), `bounce`, `stagger`, `fade`, `typing` (letter by letter), and `none`.
 - **Typography (`font`)**: Selectable fonts including `inter`, `roboto`, `nunito`, `mono` (JetBrains Mono), `serif` (Source Serif 4), and `system`.
 - **Styling Options**:
   - `fontSize`: Pixel font size (default: 18px).
@@ -144,7 +144,7 @@ A customizable multi-chat widget and stream chat box overlay that merges Twitch 
   - `sevenTv` (`true` | `false`), `badges` (`true` | `false`)
   - `fontSize` (number), `font` (`inter` | `roboto` | `nunito` | `mono` | `serif` | `system`)
   - `layout` (`inline` | `stacked` | `card` | `compact`)
-  - `animation` (`slide` | `pop` | `bounce` | `stagger` | `fade` | `none`)
+  - `animation` (`slide` | `pop` | `bounce` | `stagger` | `fade` | `typing` | `none`)
   - `background` (`true` | `false`), `bgOpacity` (string: 0.0 - 1.0)
   - `itemBackground` (`true` | `false`)
   - `boldUsernames` (`true` | `false`), `boldMessages` (`true` | `false`)

--- a/apps/extensions/llms.txt
+++ b/apps/extensions/llms.txt
@@ -135,7 +135,7 @@ A customizable multi-chat widget and stream chat box overlay that merges Twitch 
   - `itemBackground`: Individual bordered background box for each chat message item.
   - `boldUsernames` & `boldMessages`: Bold font weight toggles.
   - `orientation`: `vertical` (sidebar) or `horizontal` (ticker/bottom bar).
-  - `platformDisplay`: `icon` (Twitch/Kick platform logos) or `name` (text label).
+  - `platformDisplay`: `icon` (Twitch/Kick platform logos), `name` (text label), or `none` (hidden, e.g. when `platformAccent` already marks the platform).
   - `timestamp`: Shows timestamp (`HH:MM`) on each message.
   - `keepMessages`: Toggle 30s auto-fade vs permanent on-screen message history.
   - `mock`: Realistic simulated stream chat in preview when channels are blank.
@@ -148,7 +148,7 @@ A customizable multi-chat widget and stream chat box overlay that merges Twitch 
   - `background` (`true` | `false`), `bgOpacity` (string: 0.0 - 1.0)
   - `itemBackground` (`true` | `false`)
   - `boldUsernames` (`true` | `false`), `boldMessages` (`true` | `false`)
-  - `orientation` (`vertical` | `horizontal`), `platformDisplay` (`name` | `icon`)
+  - `orientation` (`vertical` | `horizontal`), `platformDisplay` (`name` | `icon` | `none`)
   - `timestamp` (`true` | `false`), `keep` (`true` | `false`), `mock` (`true` | `false`)
 
 ---

--- a/apps/extensions/src/lib/i18n/en.ts
+++ b/apps/extensions/src/lib/i18n/en.ts
@@ -81,6 +81,7 @@ export const en = {
     animBounce: 'Bounce in',
     animStagger: 'Stagger (meta first, then message)',
     animFade: 'Fade in',
+    animTyping: 'Typewriter',
     animNone: 'No animation',
     orientation: 'Orientation',
     vertical: 'Vertical',

--- a/apps/extensions/src/lib/i18n/en.ts
+++ b/apps/extensions/src/lib/i18n/en.ts
@@ -77,6 +77,7 @@ export const en = {
     layoutCompact: 'Compact (Twitch-like)',
     newMessageAnimation: 'New Message Animation',
     animSlide: 'Slide from right + fade',
+    animSmoothSlide: 'Smooth slide from right',
     animPop: 'Pop / scale-in',
     animBounce: 'Bounce in',
     animStagger: 'Stagger (meta first, then message)',
@@ -101,6 +102,9 @@ export const en = {
     boldMessages: 'Bold Messages',
     previewTitle: 'Widget Preview (Chat Box)',
     previewIframeTitle: 'Chat Widget Preview',
+    previewSpeed: 'Preview Chat Speed',
+    previewSpeedValue: '{rate} msg/s',
+    previewSpeedHint: 'Only changes the preview. Your widget URL stays the same.',
     previewHint: 'Live chat preview with animated message stream.',
     guideTitle: 'Streaming Software Chat Box Setup (OBS, Streamlabs, XSplit, etc.)',
     guideStep1:

--- a/apps/extensions/src/lib/i18n/en.ts
+++ b/apps/extensions/src/lib/i18n/en.ts
@@ -67,6 +67,7 @@ export const en = {
     platformIndicator: 'Platform Indicator',
     platformName: 'Platform Name',
     platformIcon: 'Platform Icon',
+    platformHidden: 'Hide Platform',
     styleSection: 'Style & Appearance (Customizable Stream Overlays)',
     font: 'Font',
     fontSystem: 'System Default',

--- a/apps/extensions/src/lib/i18n/tr.ts
+++ b/apps/extensions/src/lib/i18n/tr.ts
@@ -83,6 +83,7 @@ export const tr: typeof en = {
     animBounce: 'Zıplayarak gir',
     animStagger: 'Sıralı (önce bilgi, sonra mesaj)',
     animFade: 'Solayarak belir',
+    animTyping: 'Daktilo gibi yaz',
     animNone: 'Animasyon yok',
     orientation: 'Yön',
     vertical: 'Dikey',

--- a/apps/extensions/src/lib/i18n/tr.ts
+++ b/apps/extensions/src/lib/i18n/tr.ts
@@ -79,6 +79,7 @@ export const tr: typeof en = {
     layoutCompact: 'Kompakt (Twitch benzeri)',
     newMessageAnimation: 'Yeni Mesaj Animasyonu',
     animSlide: 'Sağdan kayarak gir + solma',
+    animSmoothSlide: 'Sağdan yumuşakça kayarak gir',
     animPop: 'Belirerek büyü / ölçeklen',
     animBounce: 'Zıplayarak gir',
     animStagger: 'Sıralı (önce bilgi, sonra mesaj)',
@@ -104,6 +105,9 @@ export const tr: typeof en = {
     boldMessages: 'Kalın Mesajlar',
     previewTitle: 'Widget Önizleme (Sohbet Kutusu)',
     previewIframeTitle: 'Sohbet Widget Önizleme',
+    previewSpeed: 'Önizleme Sohbet Hızı',
+    previewSpeedValue: '{rate} mesaj/sn',
+    previewSpeedHint: "Sadece önizlemeyi etkiler, widget URL'si değişmez.",
     previewHint: 'Animasyonlu mesaj akışıyla canlı sohbet önizlemesi.',
     guideTitle: 'Yayın Yazılımı Sohbet Kutusu Kurulumu (OBS, Streamlabs, XSplit vb.)',
     guideStep1:

--- a/apps/extensions/src/lib/i18n/tr.ts
+++ b/apps/extensions/src/lib/i18n/tr.ts
@@ -69,6 +69,7 @@ export const tr: typeof en = {
     platformIndicator: 'Platform Göstergesi',
     platformName: 'Platform Adı',
     platformIcon: 'Platform Simgesi',
+    platformHidden: 'Platformu Gizle',
     styleSection: 'Stil ve Görünüm (Özelleştirilebilir Yayın Kaplamaları)',
     font: 'Yazı Tipi',
     fontSystem: 'Sistem Varsayılanı',

--- a/apps/extensions/src/routes/setup/chat-widget.tsx
+++ b/apps/extensions/src/routes/setup/chat-widget.tsx
@@ -125,7 +125,7 @@ function ChatWidgetSetup() {
   const [platforms, setPlatforms] = useState<"both" | "twitch" | "kick">(
     "both",
   );
-  const [platformDisplay, setPlatformDisplay] = useState<"name" | "icon">(
+  const [platformDisplay, setPlatformDisplay] = useState<"name" | "icon" | "none">(
     "icon",
   );
   const [sevenTv, setSevenTv] = useState(true);
@@ -372,11 +372,12 @@ function ChatWidgetSetup() {
                   <select
                     value={platformDisplay}
                     onChange={(e) =>
-                      setPlatformDisplay(e.target.value as "name" | "icon")
+                      setPlatformDisplay(e.target.value as "name" | "icon" | "none")
                     }
                     className="w-full rounded-md border border-zinc-300 bg-zinc-100 px-3 py-2.5 text-zinc-900 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500">
                     <option value="name">{t("chatWidget.platformName")}</option>
                     <option value="icon">{t("chatWidget.platformIcon")}</option>
+                    <option value="none">{t("chatWidget.platformHidden")}</option>
                   </select>
                 </div>
               )}

--- a/apps/extensions/src/routes/setup/chat-widget.tsx
+++ b/apps/extensions/src/routes/setup/chat-widget.tsx
@@ -136,7 +136,7 @@ function ChatWidgetSetup() {
     "inline" | "stacked" | "card" | "compact"
   >("inline");
   const [animation, setAnimation] = useState<
-    "slide" | "pop" | "bounce" | "stagger" | "fade" | "none"
+    "slide" | "pop" | "bounce" | "stagger" | "fade" | "typing" | "none"
   >("slide");
   const [copied, setCopied] = useState(false);
   const [mounted, setMounted] = useState(false);
@@ -443,6 +443,7 @@ function ChatWidgetSetup() {
                             | "bounce"
                             | "stagger"
                             | "fade"
+                            | "typing"
                             | "none",
                         )
                       }
@@ -454,6 +455,7 @@ function ChatWidgetSetup() {
                         {t("chatWidget.animStagger")}
                       </option>
                       <option value="fade">{t("chatWidget.animFade")}</option>
+                      <option value="typing">{t("chatWidget.animTyping")}</option>
                       <option value="none">{t("chatWidget.animNone")}</option>
                     </select>
                   </div>

--- a/apps/extensions/src/routes/setup/chat-widget.tsx
+++ b/apps/extensions/src/routes/setup/chat-widget.tsx
@@ -105,6 +105,9 @@ export const Route = createFileRoute("/setup/chat-widget")({
   component: ChatWidgetSetup,
 });
 
+// Messages per second for the mock preview only; index 0 keeps the widget's default mock pace.
+const PREVIEW_RATES = [0.3, 0.5, 1, 2, 3, 5, 10, 15, 20];
+
 function ChatWidgetSetup() {
   const { locale, t } = useI18n();
   const [twitchChannel, setTwitchChannel] = useState("");
@@ -136,8 +139,9 @@ function ChatWidgetSetup() {
     "inline" | "stacked" | "card" | "compact"
   >("inline");
   const [animation, setAnimation] = useState<
-    "slide" | "pop" | "bounce" | "stagger" | "fade" | "typing" | "none"
+    "slide" | "smooth" | "pop" | "bounce" | "stagger" | "fade" | "typing" | "none"
   >("slide");
+  const [previewRateIndex, setPreviewRateIndex] = useState(0);
   const [copied, setCopied] = useState(false);
   const [mounted, setMounted] = useState(false);
 
@@ -228,6 +232,8 @@ function ChatWidgetSetup() {
     if (layout !== "inline") params.append("layout", layout);
     if (animation !== "slide") params.append("animation", animation);
     params.append("mock", "true");
+    if (previewRateIndex > 0)
+      params.append("mockRate", String(PREVIEW_RATES[previewRateIndex]));
     params.append("lang", locale);
     return `${window.location.origin}/widgets/chat-widget?${params.toString()}`;
   }, [
@@ -250,6 +256,7 @@ function ChatWidgetSetup() {
     font,
     layout,
     animation,
+    previewRateIndex,
     locale,
   ]);
 
@@ -439,6 +446,7 @@ function ChatWidgetSetup() {
                         setAnimation(
                           e.target.value as
                             | "slide"
+                            | "smooth"
                             | "pop"
                             | "bounce"
                             | "stagger"
@@ -449,6 +457,7 @@ function ChatWidgetSetup() {
                       }
                       className="w-full rounded-md border border-zinc-300 bg-zinc-100 px-3 py-2.5 text-zinc-900 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500">
                       <option value="slide">{t("chatWidget.animSlide")}</option>
+                      <option value="smooth">{t("chatWidget.animSmoothSlide")}</option>
                       <option value="pop">{t("chatWidget.animPop")}</option>
                       <option value="bounce">{t("chatWidget.animBounce")}</option>
                       <option value="stagger">
@@ -671,6 +680,34 @@ function ChatWidgetSetup() {
               <p className="mt-2 text-center text-xs text-zinc-500">
                 {t("chatWidget.previewHint")}
               </p>
+
+              <div className="mt-3">
+                <div className="mb-1 flex items-center justify-between">
+                  <label
+                    htmlFor="preview-chat-speed"
+                    className="text-sm font-medium text-zinc-600 dark:text-zinc-400">
+                    {t("chatWidget.previewSpeed")}
+                  </label>
+                  <span className="text-xs text-zinc-500">
+                    {t("chatWidget.previewSpeedValue", {
+                      rate: PREVIEW_RATES[previewRateIndex],
+                    })}
+                  </span>
+                </div>
+                <input
+                  id="preview-chat-speed"
+                  type="range"
+                  min="0"
+                  max={PREVIEW_RATES.length - 1}
+                  step="1"
+                  value={previewRateIndex}
+                  onChange={(e) => setPreviewRateIndex(Number(e.target.value))}
+                  className="w-full h-2 bg-zinc-300 rounded-lg appearance-none cursor-pointer accent-green-500 dark:bg-zinc-700"
+                />
+                <p className="mt-1 text-xs text-zinc-500">
+                  {t("chatWidget.previewSpeedHint")}
+                </p>
+              </div>
 
               <div className="mt-4 hidden lg:block">
                 <label className="mb-1 block text-sm font-medium text-zinc-600 dark:text-zinc-400">

--- a/apps/extensions/src/routes/widgets/chat-widget.tsx
+++ b/apps/extensions/src/routes/widgets/chat-widget.tsx
@@ -168,7 +168,7 @@ const searchSchema = z.object({
   bgOpacity: z.coerce.number().min(0).max(1).optional().default(0.5),
   platformAccent: z.coerce.boolean().optional(),
   orientation: z.enum(['vertical', 'horizontal']).optional().default('vertical'),
-  platformDisplay: z.enum(['name', 'icon']).optional().default('icon'),
+  platformDisplay: z.enum(['name', 'icon', 'none']).optional().default('icon'),
   timestamp: z.coerce.boolean().optional(),
   keep: z.coerce.boolean().optional(),
   font: z
@@ -411,12 +411,7 @@ function RouteComponent() {
 
   const isMock = Boolean(search.mock || (!search.twitch && !kick));
 
-  const showPlatformIndicator = Boolean(
-    (search.twitch && search.kick) ||
-      isMock ||
-      search.platformDisplay === 'name' ||
-      search.platformDisplay === 'icon'
-  );
+  const showPlatformIndicator = search.platformDisplay !== 'none';
 
   const sevenTvEmoteMap = use7tvEmotes(search.sevenTv ? search.twitch : null);
 
@@ -743,7 +738,7 @@ type MessageRowProps = {
   orientation: 'vertical' | 'horizontal';
   showTimestamp: boolean;
   showPlatformIndicator: boolean;
-  platformDisplay: 'name' | 'icon';
+  platformDisplay: 'name' | 'icon' | 'none';
   twitchBadgeMap: Map<string, string> | null | undefined;
   kickSubBadges: {
     months?: number;

--- a/apps/extensions/src/routes/widgets/chat-widget.tsx
+++ b/apps/extensions/src/routes/widgets/chat-widget.tsx
@@ -12,6 +12,12 @@ import { getKickChannelInfo } from '#/lib/kick';
 import { getAccessibleColor } from '#/features/widgets/chat-widget/color-utils';
 
 const TTL_MS = 30_000;
+// Must cover the 1s `now` tick, otherwise a row can expire without ever getting its fade-out class.
+const EXIT_MS = 1_000;
+const SHIFT_TRANSITION = 'transform 400ms cubic-bezier(0.22, 1, 0.36, 1)';
+
+const getReceivedAtMs = (msg: ChatMessagesType) =>
+  msg.receivedAt?.getTime() ?? msg.timestamp.getTime();
 
 type TwitchEmoteRange = { id: string; start: number; end: number };
 
@@ -159,7 +165,7 @@ const searchSchema = z.object({
   layout: z.enum(['inline', 'stacked', 'card', 'compact']).optional().default('inline'),
   mock: z.coerce.boolean().optional(),
   animation: z
-    .enum(['slide', 'pop', 'bounce', 'stagger', 'fade', 'none'])
+    .enum(['slide', 'pop', 'bounce', 'stagger', 'fade', 'typing', 'none'])
     .optional()
     .default('slide'),
 });
@@ -225,6 +231,7 @@ const ANIMATION_CLASSES: Record<
   bounce: () => 'animate-chat-bounce-in',
   stagger: () => 'animate-chat-stagger-meta',
   fade: () => 'animate-chat-fade-in',
+  typing: () => 'animate-chat-fade-in',
   none: () => '',
 };
 
@@ -234,8 +241,65 @@ const ANIMATION_MESSAGE_CLASSES: Record<AnimationChoice, string> = {
   bounce: '',
   stagger: 'animate-chat-stagger-message',
   fade: '',
+  typing: '',
   none: '',
 };
+
+const TYPING_MS_PER_CHAR = 35;
+// Long messages type faster so no message takes longer than this to finish.
+const TYPING_MAX_MS = 1_500;
+
+// Grapheme clusters, so emoji like 🏴‍☠️ are never shown half-typed.
+const splitGraphemes = (text: string): string[] =>
+  typeof Intl.Segmenter === 'function'
+    ? Array.from(
+        new Intl.Segmenter(undefined, { granularity: 'grapheme' }).segment(text),
+        (s) => s.segment,
+      )
+    : Array.from(text);
+
+function TypedContent({ nodes }: { nodes: React.ReactNode[] }) {
+  const units = React.useMemo(
+    () =>
+      nodes.flatMap((node) => {
+        if (node == null || typeof node === 'boolean' || node === '') return [];
+        return typeof node === 'string' ? splitGraphemes(node) : [node];
+      }),
+    [nodes],
+  );
+  const [count, setCount] = React.useState(0);
+  // Kept across effect restarts so a late emote-map load doesn't retype the message from scratch.
+  const startRef = React.useRef<number | null>(null);
+
+  React.useEffect(() => {
+    startRef.current ??= performance.now();
+    const start = startRef.current;
+    const msPerUnit = Math.min(TYPING_MS_PER_CHAR, TYPING_MAX_MS / Math.max(units.length, 1));
+    const id = window.setInterval(() => {
+      const next = Math.min(units.length, Math.ceil((performance.now() - start) / msPerUnit));
+      setCount(next);
+      if (next >= units.length) window.clearInterval(id);
+    }, 30);
+    return () => window.clearInterval(id);
+  }, [units.length]);
+
+  if (count >= units.length) return <>{nodes}</>;
+
+  const caretUnit = count > 0 ? units[count - 1] : null;
+  // The untyped rest stays in the layout (just invisible) so the row has its final size from the
+  // first frame; otherwise every wrapped line would push older rows up again.
+  return (
+    <>
+      {units.slice(0, Math.max(count - 1, 0))}
+      {typeof caretUnit === 'string' ? (
+        <span className="chat-typing-caret">{caretUnit}</span>
+      ) : (
+        caretUnit
+      )}
+      <span style={{ visibility: 'hidden' }}>{units.slice(count)}</span>
+    </>
+  );
+}
 
 const PLATFORM_COLORS: Record<'twitch' | 'kick', string> = {
   twitch: '#9146FF',
@@ -507,7 +571,8 @@ function RouteComponent() {
   }, [isMock]);
 
   const [now, setNow] = React.useState(() => Date.now());
-  const containerRef = React.useRef<HTMLDivElement>(null);
+  const listRef = React.useRef<HTMLDivElement>(null);
+  const lastIdRef = React.useRef<string | null>(null);
 
   React.useEffect(() => {
     if (typeof document === 'undefined') return;
@@ -550,10 +615,8 @@ function RouteComponent() {
 
   const visibleMessages = search.keep
     ? messages
-    : messages.filter((msg) => {
-      const receivedAtMs = msg.receivedAt?.getTime() ?? msg.timestamp.getTime();
-      return now - receivedAtMs < TTL_MS;
-    });
+    : messages.filter((msg) => now - getReceivedAtMs(msg) < TTL_MS);
+  const fadeOut = !search.keep && search.animation !== 'none';
 
   const hasVisibleMessages = visibleMessages.length > 0;
 
@@ -572,54 +635,85 @@ function RouteComponent() {
     };
   }, [hasVisibleMessages, search.keep]);
 
-  React.useEffect(() => {
-    if (!containerRef.current) return;
+  // The list is anchored to the bottom (right when horizontal), so appending a row makes every
+  // older row jump by its size. Offset the list back by that jump, then transition it to rest.
+  React.useLayoutEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const horizontal = search.orientation === 'horizontal';
+    // Measured from the new rows themselves rather than a stored position, so a late image load
+    // that resized an older row is not replayed as a shift.
+    const endOf = (el: HTMLElement) =>
+      horizontal ? el.offsetLeft + el.offsetWidth : el.offsetTop + el.offsetHeight;
 
-    if (search.orientation === 'horizontal') {
-      containerRef.current.scrollLeft = containerRef.current.scrollWidth;
-    } else {
-      containerRef.current.scrollTop = containerRef.current.scrollHeight;
-    }
-  }, [visibleMessages, search.orientation]);
+    const prevId = lastIdRef.current;
+    const last = list.lastElementChild as HTMLElement | null;
+    lastIdRef.current = last?.dataset.msgId ?? null;
+    if (!prevId || !last || prevId === lastIdRef.current || search.animation === 'none') return;
 
+    const prevEl = list.querySelector<HTMLElement>(`[data-msg-id="${CSS.escape(prevId)}"]`);
+    if (!prevEl) return;
+    const shift = endOf(last) - endOf(prevEl);
+    if (shift <= 0) return;
+
+    // Carry over what is left of a shift that is still running so back-to-back messages don't jump.
+    const running = new DOMMatrixReadOnly(getComputedStyle(list).transform);
+    const start = shift + (horizontal ? running.m41 : running.m42);
+    list.style.transition = 'none';
+    list.style.transform = horizontal ? `translateX(${start}px)` : `translateY(${start}px)`;
+    void list.offsetWidth;
+    list.style.transition = SHIFT_TRANSITION;
+    list.style.transform = '';
+  });
+
+  const horizontal = search.orientation === 'horizontal';
+
+  // Rows overflow toward the start edge, which is never scrollable, so clip instead of scroll:
+  // a scrollable box would flash a scrollbar while the list is offset during the shift.
   return (
     <div
-      ref={containerRef}
-      className={`flex ${search.orientation === 'horizontal' ? 'flex-row justify-end items-center overflow-hidden min-w-full h-screen p-2 space-x-3' : 'flex-col justify-end h-screen w-full overflow-y-auto overflow-x-hidden p-2.5 space-y-2'} text-white rounded-md`}
+      className={`flex ${horizontal ? 'flex-row justify-end items-center min-w-full h-screen p-2' : 'flex-col justify-end h-screen w-full p-2.5'} overflow-clip text-white rounded-md`}
       style={{
         fontSize: `${search.fontSize}px`,
         fontFamily: FONT_STACKS[search.font],
         backgroundColor: search.background ? `rgba(0, 0, 0, ${search.bgOpacity})` : 'transparent',
       }}
     >
-      {visibleMessages.map((msg) => (
-        <MessageRow
-          key={msg.id}
-          msg={msg}
-          layout={search.layout}
-          animation={search.animation}
-          orientation={search.orientation}
-          showTimestamp={Boolean(search.timestamp)}
-          showPlatformIndicator={showPlatformIndicator}
-          platformDisplay={search.platformDisplay}
-          twitchBadgeMap={twitchBadgeMap}
-          kickSubBadges={kickSubBadges}
-          sevenTvEmoteMap={sevenTvEmoteMap}
-          showBadges={Boolean(search.badges)}
-          hasBackground={Boolean(search.background)}
-          itemBackground={Boolean(search.itemBackground)}
-          bgOpacity={search.bgOpacity}
-          platformAccent={Boolean(search.platformAccent)}
-          boldUsernames={Boolean(search.boldUsernames)}
-          boldMessages={Boolean(search.boldMessages)}
-        />
-      ))}
+      <div
+        ref={listRef}
+        className={`flex ${horizontal ? 'flex-row items-center space-x-3' : 'flex-col space-y-2'}`}
+      >
+        {visibleMessages.map((msg) => (
+          <MessageRow
+            key={msg.id}
+            msg={msg}
+            exiting={fadeOut && now - getReceivedAtMs(msg) >= TTL_MS - EXIT_MS}
+            layout={search.layout}
+            animation={search.animation}
+            orientation={search.orientation}
+            showTimestamp={Boolean(search.timestamp)}
+            showPlatformIndicator={showPlatformIndicator}
+            platformDisplay={search.platformDisplay}
+            twitchBadgeMap={twitchBadgeMap}
+            kickSubBadges={kickSubBadges}
+            sevenTvEmoteMap={sevenTvEmoteMap}
+            showBadges={Boolean(search.badges)}
+            hasBackground={Boolean(search.background)}
+            itemBackground={Boolean(search.itemBackground)}
+            bgOpacity={search.bgOpacity}
+            platformAccent={Boolean(search.platformAccent)}
+            boldUsernames={Boolean(search.boldUsernames)}
+            boldMessages={Boolean(search.boldMessages)}
+          />
+        ))}
+      </div>
     </div>
   );
 }
 
 type MessageRowProps = {
   msg: ChatMessagesType;
+  exiting: boolean;
   layout: LayoutChoice;
   animation: AnimationChoice;
   orientation: 'vertical' | 'horizontal';
@@ -643,6 +737,7 @@ type MessageRowProps = {
 
 const MessageRow = React.memo(function MessageRow({
   msg,
+  exiting,
   layout,
   animation,
   orientation,
@@ -661,7 +756,7 @@ const MessageRow = React.memo(function MessageRow({
   boldMessages,
 }: MessageRowProps) {
   const classes = LAYOUT_CLASSES[layout];
-  const animClass = ANIMATION_CLASSES[animation](orientation);
+  const animClass = exiting ? 'animate-chat-fade-out' : ANIMATION_CLASSES[animation](orientation);
   const messageAnimClass = ANIMATION_MESSAGE_CLASSES[animation];
   const compactSize = layout === 'compact' ? '0.875em' : undefined;
   const isInlineOrCompact = layout === 'inline' || layout === 'compact';
@@ -766,12 +861,13 @@ const MessageRow = React.memo(function MessageRow({
   const messageNode = (
     <span className={`${classes.message} ${messageAnimClass}`} style={messageStyle}>
       {layout === 'inline' || layout === 'compact' ? ' ' : null}
-      {parsedContent}
+      {animation === 'typing' ? <TypedContent nodes={parsedContent} /> : parsedContent}
     </span>
   );
 
   return (
     <div
+      data-msg-id={msg.id}
       className={`${classes.wrapper} ${itemBgClass} ${animClass} transform-gpu ${orientation === 'horizontal' ? 'flex-shrink-0' : ''}`}
       style={wrapperStyle}
     >

--- a/apps/extensions/src/routes/widgets/chat-widget.tsx
+++ b/apps/extensions/src/routes/widgets/chat-widget.tsx
@@ -14,10 +14,23 @@ import { getAccessibleColor } from '#/features/widgets/chat-widget/color-utils';
 const TTL_MS = 30_000;
 // Must cover the 1s `now` tick, otherwise a row can expire without ever getting its fade-out class.
 const EXIT_MS = 1_000;
-const SHIFT_TRANSITION = 'transform 400ms cubic-bezier(0.22, 1, 0.36, 1)';
+const SHIFT_MS = 400;
+// Busy chat speeds animations up so each one finishes before the next message lands: full speed
+// when messages are SPEED_BASE_GAP_MS or more apart, scaled down with the gap, never below MIN_SPEED.
+const SPEED_BASE_GAP_MS = 500;
+const MIN_SPEED = 0.35;
 
 const getReceivedAtMs = (msg: ChatMessagesType) =>
   msg.receivedAt?.getTime() ?? msg.timestamp.getTime();
+
+const getAnimationSpeeds = (messages: ChatMessagesType[]) => {
+  const speeds = new Map<string, number>();
+  messages.forEach((msg, i) => {
+    const gap = i > 0 ? getReceivedAtMs(msg) - getReceivedAtMs(messages[i - 1]) : Infinity;
+    speeds.set(msg.id, Math.min(1, Math.max(MIN_SPEED, gap / SPEED_BASE_GAP_MS)));
+  });
+  return speeds;
+};
 
 type TwitchEmoteRange = { id: string; start: number; end: number };
 
@@ -164,8 +177,9 @@ const searchSchema = z.object({
     .default('inter'),
   layout: z.enum(['inline', 'stacked', 'card', 'compact']).optional().default('inline'),
   mock: z.coerce.boolean().optional(),
+  mockRate: z.coerce.number().min(0.1).max(50).optional(),
   animation: z
-    .enum(['slide', 'pop', 'bounce', 'stagger', 'fade', 'typing', 'none'])
+    .enum(['slide', 'smooth', 'pop', 'bounce', 'stagger', 'fade', 'typing', 'none'])
     .optional()
     .default('slide'),
 });
@@ -227,6 +241,7 @@ const ANIMATION_CLASSES: Record<
   (orientation: 'vertical' | 'horizontal') => string
 > = {
   slide: () => 'animate-chat-slide-in',
+  smooth: () => 'animate-chat-smooth-slide-in',
   pop: () => 'animate-chat-pop-in',
   bounce: () => 'animate-chat-bounce-in',
   stagger: () => 'animate-chat-stagger-meta',
@@ -237,6 +252,7 @@ const ANIMATION_CLASSES: Record<
 
 const ANIMATION_MESSAGE_CLASSES: Record<AnimationChoice, string> = {
   slide: '',
+  smooth: '',
   pop: '',
   bounce: '',
   stagger: 'animate-chat-stagger-message',
@@ -258,7 +274,7 @@ const splitGraphemes = (text: string): string[] =>
       )
     : Array.from(text);
 
-function TypedContent({ nodes }: { nodes: React.ReactNode[] }) {
+function TypedContent({ nodes, speed }: { nodes: React.ReactNode[]; speed: number }) {
   const units = React.useMemo(
     () =>
       nodes.flatMap((node) => {
@@ -274,14 +290,15 @@ function TypedContent({ nodes }: { nodes: React.ReactNode[] }) {
   React.useEffect(() => {
     startRef.current ??= performance.now();
     const start = startRef.current;
-    const msPerUnit = Math.min(TYPING_MS_PER_CHAR, TYPING_MAX_MS / Math.max(units.length, 1));
+    const msPerUnit =
+      speed * Math.min(TYPING_MS_PER_CHAR, TYPING_MAX_MS / Math.max(units.length, 1));
     const id = window.setInterval(() => {
       const next = Math.min(units.length, Math.ceil((performance.now() - start) / msPerUnit));
       setCount(next);
       if (next >= units.length) window.clearInterval(id);
     }, 30);
     return () => window.clearInterval(id);
-  }, [units.length]);
+  }, [units.length, speed]);
 
   if (count >= units.length) return <>{nodes}</>;
 
@@ -559,7 +576,7 @@ function RouteComponent() {
     };
 
     const firstTimer = setTimeout(insertNextMock, 400);
-    const interval = setInterval(insertNextMock, 3000);
+    const interval = setInterval(insertNextMock, search.mockRate ? 1000 / search.mockRate : 3000);
 
     return () => {
       clearTimeout(firstTimer);
@@ -568,7 +585,7 @@ function RouteComponent() {
         chatMessagesCollection.delete(id);
       }
     };
-  }, [isMock]);
+  }, [isMock, search.mockRate]);
 
   const [now, setNow] = React.useState(() => Date.now());
   const listRef = React.useRef<HTMLDivElement>(null);
@@ -616,7 +633,11 @@ function RouteComponent() {
   const visibleMessages = search.keep
     ? messages
     : messages.filter((msg) => now - getReceivedAtMs(msg) < TTL_MS);
-  const fadeOut = !search.keep && search.animation !== 'none';
+  // `slide` is the original default and must look exactly as it always did, so the shift and
+  // fade-out only come with the other animations.
+  const animatesLayout = search.animation !== 'none' && search.animation !== 'slide';
+  const fadeOut = !search.keep && animatesLayout;
+  const speeds = React.useMemo(() => getAnimationSpeeds(messages), [messages]);
 
   const hasVisibleMessages = visibleMessages.length > 0;
 
@@ -649,7 +670,7 @@ function RouteComponent() {
     const prevId = lastIdRef.current;
     const last = list.lastElementChild as HTMLElement | null;
     lastIdRef.current = last?.dataset.msgId ?? null;
-    if (!prevId || !last || prevId === lastIdRef.current || search.animation === 'none') return;
+    if (!prevId || !last || prevId === lastIdRef.current || !animatesLayout) return;
 
     const prevEl = list.querySelector<HTMLElement>(`[data-msg-id="${CSS.escape(prevId)}"]`);
     if (!prevEl) return;
@@ -662,7 +683,8 @@ function RouteComponent() {
     list.style.transition = 'none';
     list.style.transform = horizontal ? `translateX(${start}px)` : `translateY(${start}px)`;
     void list.offsetWidth;
-    list.style.transition = SHIFT_TRANSITION;
+    const shiftMs = Math.round(SHIFT_MS * (speeds.get(lastIdRef.current ?? '') ?? 1));
+    list.style.transition = `transform ${shiftMs}ms cubic-bezier(0.22, 1, 0.36, 1)`;
     list.style.transform = '';
   });
 
@@ -688,6 +710,7 @@ function RouteComponent() {
             key={msg.id}
             msg={msg}
             exiting={fadeOut && now - getReceivedAtMs(msg) >= TTL_MS - EXIT_MS}
+            speed={speeds.get(msg.id) ?? 1}
             layout={search.layout}
             animation={search.animation}
             orientation={search.orientation}
@@ -714,6 +737,7 @@ function RouteComponent() {
 type MessageRowProps = {
   msg: ChatMessagesType;
   exiting: boolean;
+  speed: number;
   layout: LayoutChoice;
   animation: AnimationChoice;
   orientation: 'vertical' | 'horizontal';
@@ -738,6 +762,7 @@ type MessageRowProps = {
 const MessageRow = React.memo(function MessageRow({
   msg,
   exiting,
+  speed,
   layout,
   animation,
   orientation,
@@ -755,6 +780,9 @@ const MessageRow = React.memo(function MessageRow({
   boldUsernames,
   boldMessages,
 }: MessageRowProps) {
+  // Frozen at mount: a moderator deleting the previous message would otherwise change this row's
+  // speed mid-animation and make it jump (or un-type letters in typing mode).
+  const [mountSpeed] = React.useState(speed);
   const classes = LAYOUT_CLASSES[layout];
   const animClass = exiting ? 'animate-chat-fade-out' : ANIMATION_CLASSES[animation](orientation);
   const messageAnimClass = ANIMATION_MESSAGE_CLASSES[animation];
@@ -861,7 +889,11 @@ const MessageRow = React.memo(function MessageRow({
   const messageNode = (
     <span className={`${classes.message} ${messageAnimClass}`} style={messageStyle}>
       {layout === 'inline' || layout === 'compact' ? ' ' : null}
-      {animation === 'typing' ? <TypedContent nodes={parsedContent} /> : parsedContent}
+      {animation === 'typing' ? (
+        <TypedContent nodes={parsedContent} speed={mountSpeed} />
+      ) : (
+        parsedContent
+      )}
     </span>
   );
 
@@ -869,7 +901,7 @@ const MessageRow = React.memo(function MessageRow({
     <div
       data-msg-id={msg.id}
       className={`${classes.wrapper} ${itemBgClass} ${animClass} transform-gpu ${orientation === 'horizontal' ? 'flex-shrink-0' : ''}`}
-      style={wrapperStyle}
+      style={{ ...wrapperStyle, '--chat-speed': mountSpeed } as React.CSSProperties}
     >
       {isInlineOrCompact ? (
         <>

--- a/apps/extensions/src/routes/widgets/chat-widget.tsx
+++ b/apps/extensions/src/routes/widgets/chat-widget.tsx
@@ -365,12 +365,14 @@ export const Route = createFileRoute('/widgets/chat-widget')({
   },
 });
 
+// Both viewBoxes are cropped horizontally to the glyph's own bounds: the stock 24x24 boxes pad
+// Twitch 3 units but Kick only 1.33, so Kick sat visibly further left and closer to the badges.
 function TwitchIcon({ className, ...props }: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      className={`inline-block h-[1.15em] w-[1.15em] ${className ?? ''}`}
-      viewBox="0 0 24 24"
+      className={`inline-block h-[1.15em] w-auto ${className ?? ''}`}
+      viewBox="3 0 18.006 24"
       {...props}
     >
       <path
@@ -385,9 +387,9 @@ function KickIcon({ className, ...props }: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
       role="img"
-      viewBox="0 0 24 24"
+      viewBox="1.333 0 21.334 24"
       fill="currentColor"
-      className={`inline-block h-[1em] w-[1em] ${className ?? ''}`}
+      className={`inline-block h-[1em] w-auto ${className ?? ''}`}
       {...props}
     >
       <title>Kick</title>

--- a/apps/extensions/src/routes/widgets/chat-widget.tsx
+++ b/apps/extensions/src/routes/widgets/chat-widget.tsx
@@ -387,7 +387,7 @@ function KickIcon({ className, ...props }: React.SVGProps<SVGSVGElement>) {
       role="img"
       viewBox="0 0 24 24"
       fill="currentColor"
-      className={`inline-block h-[1.15em] w-[1.15em] ${className ?? ''}`}
+      className={`inline-block h-[1em] w-[1em] ${className ?? ''}`}
       {...props}
     >
       <title>Kick</title>

--- a/apps/extensions/src/styles.css
+++ b/apps/extensions/src/styles.css
@@ -45,7 +45,7 @@
 }
 
 .animate-chat-bounce-in {
-  animation: chatBounceIn 500ms ease-out forwards;
+  animation: chatBounceIn calc(500ms * var(--chat-speed, 1)) ease-out forwards;
 }
 
 @keyframes chatSlideIn {
@@ -60,7 +60,12 @@
 }
 
 .animate-chat-slide-in {
-  animation: chatSlideIn 380ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation: chatSlideIn 200ms ease-out both;
+}
+
+/* --chat-speed is set per row from how busy chat is (1 = calm); see getAnimationSpeeds. */
+.animate-chat-smooth-slide-in {
+  animation: chatSlideIn calc(380ms * var(--chat-speed, 1)) cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
 /* The easing already overshoots, so a mid-keyframe overshoot would double it. */
@@ -76,7 +81,7 @@
 }
 
 .animate-chat-pop-in {
-  animation: chatPopIn 380ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  animation: chatPopIn calc(380ms * var(--chat-speed, 1)) cubic-bezier(0.34, 1.56, 0.64, 1) both;
   transform-origin: right center;
 }
 
@@ -92,7 +97,7 @@
 }
 
 .animate-chat-stagger-meta {
-  animation: chatStaggerMeta 320ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation: chatStaggerMeta calc(320ms * var(--chat-speed, 1)) cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
 @keyframes chatStaggerMessage {
@@ -107,7 +112,8 @@
 }
 
 .animate-chat-stagger-message {
-  animation: chatStaggerMessage 320ms cubic-bezier(0.22, 1, 0.36, 1) 150ms both;
+  animation: chatStaggerMessage calc(320ms * var(--chat-speed, 1)) cubic-bezier(0.22, 1, 0.36, 1)
+    calc(150ms * var(--chat-speed, 1)) both;
 }
 
 @keyframes chatFadeIn {
@@ -120,7 +126,7 @@
 }
 
 .animate-chat-fade-in {
-  animation: chatFadeIn 350ms ease-out both;
+  animation: chatFadeIn calc(350ms * var(--chat-speed, 1)) ease-out both;
 }
 
 /* Box-shadow instead of an extra caret element: it paints outside the glyph without taking up

--- a/apps/extensions/src/styles.css
+++ b/apps/extensions/src/styles.css
@@ -60,17 +60,14 @@
 }
 
 .animate-chat-slide-in {
-  animation: chatSlideIn 200ms ease-out both;
+  animation: chatSlideIn 380ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
+/* The easing already overshoots, so a mid-keyframe overshoot would double it. */
 @keyframes chatPopIn {
   0% {
     opacity: 0;
-    transform: scale(0.6);
-  }
-  60% {
-    opacity: 1;
-    transform: scale(1.05);
+    transform: scale(0.85);
   }
   100% {
     opacity: 1;
@@ -79,7 +76,7 @@
 }
 
 .animate-chat-pop-in {
-  animation: chatPopIn 300ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  animation: chatPopIn 380ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
   transform-origin: right center;
 }
 
@@ -95,7 +92,7 @@
 }
 
 .animate-chat-stagger-meta {
-  animation: chatStaggerMeta 200ms ease-out both;
+  animation: chatStaggerMeta 320ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
 @keyframes chatStaggerMessage {
@@ -110,7 +107,7 @@
 }
 
 .animate-chat-stagger-message {
-  animation: chatStaggerMessage 200ms ease-out 250ms both;
+  animation: chatStaggerMessage 320ms cubic-bezier(0.22, 1, 0.36, 1) 150ms both;
 }
 
 @keyframes chatFadeIn {
@@ -123,7 +120,23 @@
 }
 
 .animate-chat-fade-in {
-  animation: chatFadeIn 200ms ease-out both;
+  animation: chatFadeIn 350ms ease-out both;
+}
+
+/* Box-shadow instead of an extra caret element: it paints outside the glyph without taking up
+   layout space, so it can't change where the half-typed line wraps. */
+.chat-typing-caret {
+  box-shadow: 2px 0 0 currentColor;
+}
+
+@keyframes chatFadeOut {
+  to {
+    opacity: 0;
+  }
+}
+
+.animate-chat-fade-out {
+  animation: chatFadeOut 400ms ease-in forwards;
 }
 
 /* Emote wall calm mode: fade in, drift away, fade out */


### PR DESCRIPTION
Adds smoother and busy-chat-aware animation options to the chat widget. **The default `slide` animation is unchanged**, so existing widget URLs look exactly as before.

**New `smooth` animation ("Smooth slide from right")**
- When a message arrives, older rows slide up (left in horizontal mode) instead of jumping. Back-to-back messages continue the running slide instead of restarting it.
- Messages fade out before they expire (skipped with `keep=true`).

**New `typing` animation ("Typewriter")**
- The message appears letter by letter with a thin caret. Emoji and emotes count as single units.
- The untyped rest stays invisible in the layout, so wrapped messages don't push older rows while typing. Typing time scales with message length and is capped at 1.5s.

**Chat-rate aware timing** (all animations except the default `slide`)
- Each row's speed comes from the gap to the previous message: full speed at 500ms or more apart, down to 35% during bursts. Entry animation, row shift and typing speed all use it, so animations finish before the next message lands instead of piling up.
- The speed is frozen when the row mounts, so a moderator deleting the previous message can't change a running animation.
- Pop, stagger and fade got ease-out curves and slightly longer base durations. Pop no longer overshoots twice.

**Setup page**
- New "Preview Chat Speed" slider (0.3 to 20 msg/s) under the preview, to see how the widget handles slow chat vs. floods. It only adds `mockRate` to the preview URL; the copied widget URL is unaffected.

**Platform indicator**
- New "Hide Platform" option (`platformDisplay=none`) hides the platform name/icon, for streamers who already mark the platform with the color stripe (`platformAccent`). The old visibility condition was always true since `platformDisplay` defaults to `icon`, so it now reduces to a single check.

**Other**
- The message box uses `overflow: clip`. Rows overflow toward the start edge, which was never scrollable, so the old `scrollTop`/`scrollLeft` effect had no effect at rest and only fought the slide (it also flashed a scrollbar).
- Moderation deletes still remove rows instantly, same as before.
- Kick platform icon is back to 1em (its glyph fills the whole viewBox, so at Twitch's 1.15em it looked larger). Both icon viewBoxes are now cropped to the glyph bounds so Twitch and Kick start at the same x and keep the same gap to the badges.
- tr/en translations and `llms.txt` updated.