### PR TITLE
feat(extensions): redesign chat widget setup as a single-screen panel

### DIFF
--- a/apps/extensions/llms.txt
+++ b/apps/extensions/llms.txt
@@ -127,7 +127,7 @@ A customizable multi-chat widget and stream chat box overlay that merges Twitch 
   - `stacked`: Username header displayed above message body.
   - `card`: Message displayed in modern bubble/card format.
   - `compact`: Dense, Twitch-native spacing for high-velocity chats.
-- **Entry Animations (`animation`)**: `slide` (from right), `pop` (scale-in), `bounce`, `stagger`, `fade`, `typing` (letter by letter), and `none`.
+- **Entry Animations (`animation`)**: `slide` (from right), `smooth` (smoother slide, older messages glide up), `pop` (scale-in), `bounce`, `stagger`, `fade`, `typing` (letter by letter), and `none`.
 - **Typography (`font`)**: Selectable fonts including `inter`, `roboto`, `nunito`, `mono` (JetBrains Mono), `serif` (Source Serif 4), and `system`.
 - **Styling Options**:
   - `fontSize`: Pixel font size (default: 18px).
@@ -144,7 +144,7 @@ A customizable multi-chat widget and stream chat box overlay that merges Twitch 
   - `sevenTv` (`true` | `false`), `badges` (`true` | `false`)
   - `fontSize` (number), `font` (`inter` | `roboto` | `nunito` | `mono` | `serif` | `system`)
   - `layout` (`inline` | `stacked` | `card` | `compact`)
-  - `animation` (`slide` | `pop` | `bounce` | `stagger` | `fade` | `typing` | `none`)
+  - `animation` (`slide` | `smooth` | `pop` | `bounce` | `stagger` | `fade` | `typing` | `none`)
   - `background` (`true` | `false`), `bgOpacity` (string: 0.0 - 1.0)
   - `itemBackground` (`true` | `false`)
   - `boldUsernames` (`true` | `false`), `boldMessages` (`true` | `false`)

--- a/apps/extensions/llms.txt
+++ b/apps/extensions/llms.txt
@@ -127,7 +127,7 @@ A customizable multi-chat widget and stream chat box overlay that merges Twitch 
   - `stacked`: Username header displayed above message body.
   - `card`: Message displayed in modern bubble/card format.
   - `compact`: Dense, Twitch-native spacing for high-velocity chats.
-- **Entry Animations (`animation`)**: `slide` (from right), `pop` (scale-in), `bounce`, `stagger`, `fade`, and `none`.
+- **Entry Animations (`animation`)**: `slide` (from right), `pop` (scale-in), `bounce`, `stagger`, `fade`, `typing` (letter by letter), and `none`.
 - **Typography (`font`)**: Selectable fonts including `inter`, `roboto`, `nunito`, `mono` (JetBrains Mono), `serif` (Source Serif 4), and `system`.
 - **Styling Options**:
   - `fontSize`: Pixel font size (default: 18px).
@@ -144,7 +144,7 @@ A customizable multi-chat widget and stream chat box overlay that merges Twitch 
   - `sevenTv` (`true` | `false`), `badges` (`true` | `false`)
   - `fontSize` (number), `font` (`inter` | `roboto` | `nunito` | `mono` | `serif` | `system`)
   - `layout` (`inline` | `stacked` | `card` | `compact`)
-  - `animation` (`slide` | `pop` | `bounce` | `stagger` | `fade` | `none`)
+  - `animation` (`slide` | `pop` | `bounce` | `stagger` | `fade` | `typing` | `none`)
   - `background` (`true` | `false`), `bgOpacity` (string: 0.0 - 1.0)
   - `itemBackground` (`true` | `false`)
   - `boldUsernames` (`true` | `false`), `boldMessages` (`true` | `false`)

--- a/apps/extensions/llms.txt
+++ b/apps/extensions/llms.txt
@@ -135,7 +135,7 @@ A customizable multi-chat widget and stream chat box overlay that merges Twitch 
   - `itemBackground`: Individual bordered background box for each chat message item.
   - `boldUsernames` & `boldMessages`: Bold font weight toggles.
   - `orientation`: `vertical` (sidebar) or `horizontal` (ticker/bottom bar).
-  - `platformDisplay`: `icon` (Twitch/Kick platform logos) or `name` (text label).
+  - `platformDisplay`: `icon` (Twitch/Kick platform logos), `name` (text label), or `none` (hidden, e.g. when `platformAccent` already marks the platform).
   - `timestamp`: Shows timestamp (`HH:MM`) on each message.
   - `keepMessages`: Toggle 30s auto-fade vs permanent on-screen message history.
   - `mock`: Realistic simulated stream chat in preview when channels are blank.
@@ -148,7 +148,7 @@ A customizable multi-chat widget and stream chat box overlay that merges Twitch 
   - `background` (`true` | `false`), `bgOpacity` (string: 0.0 - 1.0)
   - `itemBackground` (`true` | `false`)
   - `boldUsernames` (`true` | `false`), `boldMessages` (`true` | `false`)
-  - `orientation` (`vertical` | `horizontal`), `platformDisplay` (`name` | `icon`)
+  - `orientation` (`vertical` | `horizontal`), `platformDisplay` (`name` | `icon` | `none`)
   - `timestamp` (`true` | `false`), `keep` (`true` | `false`), `mock` (`true` | `false`)
 
 ---

--- a/apps/extensions/src/components/ui/field-label.tsx
+++ b/apps/extensions/src/components/ui/field-label.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react';
+import { InfoTip } from './info-tip';
+
+const LABEL_CLASS = 'text-xs font-medium text-zinc-600 dark:text-zinc-400';
+
+interface FieldLabelProps {
+  children: ReactNode;
+  tip?: string;
+  // Native inputs take `htmlFor`; custom widgets reference the label through `id` and
+  // aria-labelledby, since clicking a <label> would also open or toggle them.
+  htmlFor?: string;
+  id?: string;
+}
+
+export function FieldLabel({ children, tip, htmlFor, id }: FieldLabelProps) {
+  return (
+    <div className="mb-1 flex items-center gap-1">
+      {htmlFor ? (
+        <label htmlFor={htmlFor} id={id} className={LABEL_CLASS}>
+          {children}
+        </label>
+      ) : (
+        <span id={id} className={LABEL_CLASS}>
+          {children}
+        </span>
+      )}
+      {tip && <InfoTip text={tip} />}
+    </div>
+  );
+}

--- a/apps/extensions/src/components/ui/floating.ts
+++ b/apps/extensions/src/components/ui/floating.ts
@@ -1,0 +1,85 @@
+import { type RefObject, useEffect, useLayoutEffect, useState } from 'react';
+
+const GAP = 6;
+const VIEWPORT_MARGIN = 8;
+
+export interface AnchoredPosition {
+  top: number;
+  left: number;
+  anchorWidth: number;
+}
+
+// Floating layers are portaled to <body> with fixed positioning so a scrollable settings panel
+// can't clip them. They flip above the anchor when there isn't room below.
+export function useAnchoredPosition(
+  anchorRef: RefObject<HTMLElement | null>,
+  floatingRef: RefObject<HTMLElement | null>,
+  open: boolean,
+  align: 'start' | 'center' = 'start',
+) {
+  const [position, setPosition] = useState<AnchoredPosition | null>(null);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      setPosition(null);
+      return;
+    }
+
+    const update = () => {
+      const anchor = anchorRef.current?.getBoundingClientRect();
+      const floating = floatingRef.current?.getBoundingClientRect();
+      if (!anchor || !floating) return;
+
+      const spaceBelow = window.innerHeight - anchor.bottom;
+      const fitsBelow = spaceBelow >= floating.height + GAP + VIEWPORT_MARGIN;
+      const top =
+        fitsBelow || anchor.top < spaceBelow
+          ? anchor.bottom + GAP
+          : anchor.top - GAP - floating.height;
+      const preferredLeft =
+        align === 'center' ? anchor.left + anchor.width / 2 - floating.width / 2 : anchor.left;
+      const left = Math.max(
+        VIEWPORT_MARGIN,
+        Math.min(preferredLeft, window.innerWidth - floating.width - VIEWPORT_MARGIN),
+      );
+
+      setPosition({ top, left, anchorWidth: anchor.width });
+    };
+
+    update();
+    window.addEventListener('resize', update);
+    window.addEventListener('scroll', update, true);
+    return () => {
+      window.removeEventListener('resize', update);
+      window.removeEventListener('scroll', update, true);
+    };
+  }, [open, anchorRef, floatingRef, align]);
+
+  return position;
+}
+
+// Closes on Escape or on a pointer press outside every given element.
+export function useDismiss(
+  open: boolean,
+  onDismiss: () => void,
+  refs: RefObject<HTMLElement | null>[],
+) {
+  useEffect(() => {
+    if (!open) return;
+
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target as Node;
+      if (!refs.some((ref) => ref.current?.contains(target))) onDismiss();
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onDismiss();
+    };
+
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  });
+}

--- a/apps/extensions/src/components/ui/info-tip.tsx
+++ b/apps/extensions/src/components/ui/info-tip.tsx
@@ -1,0 +1,74 @@
+import { useId, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useI18n } from '#/lib/i18n';
+import { useAnchoredPosition, useDismiss } from './floating';
+
+export function InfoTip({ text }: { text: string }) {
+  const { t } = useI18n();
+  const [open, setOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const tipRef = useRef<HTMLDivElement>(null);
+  // Mouse users get the tip on hover, so their click must not toggle it back off; touch and
+  // keyboard have no hover and rely on the click toggle.
+  const pointerTypeRef = useRef('');
+  const tipId = useId();
+  const position = useAnchoredPosition(buttonRef, tipRef, open, 'center');
+  useDismiss(open, () => setOpen(false), [buttonRef, tipRef]);
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        aria-label={t('common.moreInfo')}
+        aria-describedby={open ? tipId : undefined}
+        onPointerDown={(e) => {
+          pointerTypeRef.current = e.pointerType;
+        }}
+        onPointerEnter={(e) => e.pointerType === 'mouse' && setOpen(true)}
+        onPointerLeave={(e) => e.pointerType === 'mouse' && setOpen(false)}
+        onClick={() => {
+          const pointerType = pointerTypeRef.current;
+          pointerTypeRef.current = '';
+          if (pointerType !== 'mouse') setOpen((value) => !value);
+        }}
+        onFocus={(e) => e.currentTarget.matches(':focus-visible') && setOpen(true)}
+        onBlur={() => setOpen(false)}
+        className="-m-1 inline-flex shrink-0 items-center justify-center rounded-full p-1 text-zinc-400 transition-colors hover:text-zinc-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500 dark:text-zinc-500 dark:hover:text-zinc-200"
+      >
+        <svg
+          className="size-3.5"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          aria-hidden="true"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M9.1 9a3 3 0 0 1 5.8 1c0 2-3 3-3 3M12 17h.01"
+          />
+        </svg>
+      </button>
+      {open &&
+        createPortal(
+          <div
+            ref={tipRef}
+            id={tipId}
+            role="tooltip"
+            style={{
+              top: position?.top ?? 0,
+              left: position?.left ?? 0,
+              visibility: position ? undefined : 'hidden',
+            }}
+            className="pointer-events-none fixed z-[60] max-w-64 rounded-md bg-zinc-900 px-2.5 py-1.5 font-sans text-xs leading-relaxed text-zinc-50 shadow-lg dark:border dark:border-zinc-700 dark:bg-zinc-800"
+          >
+            {text}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/apps/extensions/src/components/ui/number-field.tsx
+++ b/apps/extensions/src/components/ui/number-field.tsx
@@ -1,0 +1,44 @@
+interface NumberFieldProps {
+  id?: string;
+  value: string;
+  onChange: (value: string) => void;
+  min: number;
+  max: number;
+  fallback: number;
+}
+
+const STEP_BUTTON_CLASS =
+  'w-8 shrink-0 text-base text-zinc-500 transition-colors hover:bg-zinc-200 hover:text-zinc-900 focus-visible:bg-zinc-200 focus-visible:outline-none dark:hover:bg-zinc-700 dark:hover:text-white dark:focus-visible:bg-zinc-700';
+
+// Typing stays free-form like the old input; only the −/+ buttons clamp to min/max.
+export function NumberField({ id, value, onChange, min, max, fallback }: NumberFieldProps) {
+  const step = (delta: number) => {
+    const current = Number(value) || fallback;
+    onChange(String(Math.min(max, Math.max(min, current + delta))));
+  };
+
+  return (
+    <div className="flex h-9 overflow-hidden rounded-md border border-zinc-300 bg-zinc-100 focus-within:border-green-500 focus-within:ring-1 focus-within:ring-green-500 dark:border-zinc-700 dark:bg-zinc-800">
+      <button type="button" onClick={() => step(-1)} className={STEP_BUTTON_CLASS}>
+        −
+      </button>
+      <input
+        id={id}
+        type="text"
+        inputMode="numeric"
+        value={value}
+        onChange={(e) => onChange(e.target.value.replace(/\D/g, ''))}
+        onKeyDown={(e) => {
+          if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+            e.preventDefault();
+            step(e.key === 'ArrowUp' ? 1 : -1);
+          }
+        }}
+        className="w-full min-w-0 bg-transparent text-center text-sm text-zinc-900 focus:outline-none dark:text-white"
+      />
+      <button type="button" onClick={() => step(1)} className={STEP_BUTTON_CLASS}>
+        +
+      </button>
+    </div>
+  );
+}

--- a/apps/extensions/src/components/ui/segmented-control.tsx
+++ b/apps/extensions/src/components/ui/segmented-control.tsx
@@ -1,0 +1,47 @@
+import { useId } from 'react';
+
+export interface SegmentedOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+interface SegmentedControlProps<T extends string> {
+  value: T;
+  onChange: (value: T) => void;
+  options: SegmentedOption<T>[];
+  labelledBy?: string;
+}
+
+// Visually hidden native radios, so the browser provides the single tab stop and arrow keys.
+export function SegmentedControl<T extends string>({
+  value,
+  onChange,
+  options,
+  labelledBy,
+}: SegmentedControlProps<T>) {
+  const name = useId();
+
+  return (
+    <fieldset
+      aria-labelledby={labelledBy}
+      className="flex h-9 min-w-0 gap-0.5 rounded-md border border-zinc-300 bg-zinc-100 p-0.5 dark:border-zinc-700 dark:bg-zinc-800"
+    >
+      {options.map((option) => (
+        <label
+          key={option.value}
+          className="flex min-w-0 flex-1 cursor-pointer items-center justify-center truncate rounded px-2 text-xs font-medium text-zinc-500 transition-colors hover:text-zinc-900 has-checked:bg-white has-checked:text-zinc-900 has-checked:shadow-sm has-focus-visible:ring-2 has-focus-visible:ring-green-500 dark:text-zinc-400 dark:hover:text-zinc-100 dark:has-checked:bg-zinc-600 dark:has-checked:text-white"
+        >
+          <input
+            type="radio"
+            name={name}
+            value={option.value}
+            checked={option.value === value}
+            onChange={() => onChange(option.value)}
+            className="sr-only"
+          />
+          {option.label}
+        </label>
+      ))}
+    </fieldset>
+  );
+}

--- a/apps/extensions/src/components/ui/select.tsx
+++ b/apps/extensions/src/components/ui/select.tsx
@@ -1,0 +1,208 @@
+import { type KeyboardEvent, useEffect, useId, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useAnchoredPosition, useDismiss } from './floating';
+
+export interface SelectOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+interface SelectProps<T extends string> {
+  value: T;
+  onChange: (value: T) => void;
+  options: SelectOption<T>[];
+  labelledBy?: string;
+  disabled?: boolean;
+}
+
+const TYPEAHEAD_RESET_MS = 500;
+
+// Listbox pattern: focus stays on the trigger and aria-activedescendant points at the
+// highlighted option, so the portaled list never needs focus of its own.
+export function Select<T extends string>({
+  value,
+  onChange,
+  options,
+  labelledBy,
+  disabled,
+}: SelectProps<T>) {
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const typeaheadRef = useRef({ query: '', at: 0 });
+  const id = useId();
+  const valueId = `${id}-value`;
+  const optionId = (index: number) => `${id}-option-${index}`;
+  const selectedIndex = Math.max(
+    0,
+    options.findIndex((option) => option.value === value),
+  );
+  const position = useAnchoredPosition(triggerRef, listRef, open);
+  useDismiss(open, () => setOpen(false), [triggerRef, listRef]);
+
+  useEffect(() => {
+    if (!open) return;
+    document.getElementById(optionId(activeIndex))?.scrollIntoView({ block: 'nearest' });
+  });
+
+  const openList = () => {
+    setActiveIndex(selectedIndex);
+    setOpen(true);
+  };
+
+  const commit = (index: number) => {
+    onChange(options[index].value);
+    setOpen(false);
+  };
+
+  // Typing a letter jumps to the next option starting with it, like a native select.
+  const findByTypeahead = (key: string) => {
+    const now = Date.now();
+    const typeahead = typeaheadRef.current;
+    typeahead.query =
+      now - typeahead.at < TYPEAHEAD_RESET_MS
+        ? typeahead.query + key.toLowerCase()
+        : key.toLowerCase();
+    typeahead.at = now;
+    const from = open ? activeIndex : selectedIndex;
+    const startOffset = typeahead.query.length > 1 ? 0 : 1;
+    for (let i = 0; i < options.length; i++) {
+      const index = (from + startOffset + i) % options.length;
+      if (options[index].label.toLowerCase().startsWith(typeahead.query)) return index;
+    }
+    return -1;
+  };
+
+  const onKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key.length === 1 && e.key !== ' ' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      const index = findByTypeahead(e.key);
+      if (index === -1) return;
+      if (open) setActiveIndex(index);
+      else onChange(options[index].value);
+      return;
+    }
+
+    if (!open) {
+      if (['ArrowDown', 'ArrowUp', 'Enter', ' '].includes(e.key)) {
+        e.preventDefault();
+        openList();
+      }
+      return;
+    }
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setActiveIndex((index) => Math.min(index + 1, options.length - 1));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setActiveIndex((index) => Math.max(index - 1, 0));
+        break;
+      case 'Home':
+        e.preventDefault();
+        setActiveIndex(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        setActiveIndex(options.length - 1);
+        break;
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        commit(activeIndex);
+        break;
+      case 'Tab':
+        setOpen(false);
+        break;
+    }
+  };
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        role="combobox"
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? `${id}-list` : undefined}
+        aria-activedescendant={open ? optionId(activeIndex) : undefined}
+        aria-labelledby={labelledBy ? `${labelledBy} ${valueId}` : valueId}
+        onClick={() => (open ? setOpen(false) : openList())}
+        onKeyDown={onKeyDown}
+        className="flex h-9 w-full items-center justify-between gap-2 rounded-md border border-zinc-300 bg-zinc-100 px-3 text-left text-sm text-zinc-900 transition-colors hover:border-zinc-400 focus-visible:border-green-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-500 disabled:cursor-not-allowed disabled:opacity-50 aria-expanded:border-green-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white dark:hover:border-zinc-600"
+      >
+        <span id={valueId} className="truncate">
+          {options[selectedIndex]?.label}
+        </span>
+        <svg
+          className={`size-4 shrink-0 text-zinc-500 transition-transform ${open ? 'rotate-180' : ''}`}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="m6 9 6 6 6-6" />
+        </svg>
+      </button>
+      {open &&
+        createPortal(
+          <div
+            ref={listRef}
+            id={`${id}-list`}
+            role="listbox"
+            aria-labelledby={labelledBy}
+            style={{
+              top: position?.top ?? 0,
+              left: position?.left ?? 0,
+              minWidth: position?.anchorWidth,
+              visibility: position ? undefined : 'hidden',
+            }}
+            className="fixed z-[60] max-h-72 overflow-y-auto rounded-md border border-zinc-200 bg-white p-1 font-sans shadow-lg dark:border-zinc-700 dark:bg-zinc-900"
+          >
+            {options.map((option, index) => {
+              const selected = index === selectedIndex;
+              return (
+                // biome-ignore lint/a11y/useKeyWithClickEvents: keyboard selection lives on the trigger via aria-activedescendant.
+                <div
+                  key={option.value}
+                  id={optionId(index)}
+                  role="option"
+                  tabIndex={-1}
+                  aria-selected={selected}
+                  // Keeps focus on the trigger so its keyboard handling keeps working.
+                  onMouseDown={(e) => e.preventDefault()}
+                  onMouseMove={() => setActiveIndex(index)}
+                  onClick={() => commit(index)}
+                  className={`flex cursor-pointer items-center justify-between gap-3 whitespace-nowrap rounded px-2.5 py-1.5 text-sm ${
+                    index === activeIndex ? 'bg-zinc-100 dark:bg-zinc-800' : ''
+                  } ${
+                    selected
+                      ? 'font-medium text-green-700 dark:text-green-400'
+                      : 'text-zinc-800 dark:text-zinc-200'
+                  }`}
+                >
+                  {option.label}
+                  <svg
+                    className={`size-4 shrink-0 ${selected ? '' : 'invisible'}`}
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2.5}
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="m5 12 5 5L20 7" />
+                  </svg>
+                </div>
+              );
+            })}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/apps/extensions/src/components/ui/switch.tsx
+++ b/apps/extensions/src/components/ui/switch.tsx
@@ -1,0 +1,43 @@
+import { useId } from 'react';
+import { InfoTip } from './info-tip';
+
+interface SwitchProps {
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  tip?: string;
+}
+
+export function Switch({ label, checked, onChange, tip }: SwitchProps) {
+  const id = useId();
+
+  return (
+    <div className="flex min-h-7 items-center justify-between gap-3">
+      <div className="flex min-w-0 items-center gap-1">
+        <label
+          htmlFor={id}
+          className="cursor-pointer text-sm leading-tight text-zinc-800 dark:text-zinc-200"
+        >
+          {label}
+        </label>
+        {tip && <InfoTip text={tip} />}
+      </div>
+      <button
+        id={id}
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-zinc-900 ${
+          checked ? 'bg-green-500' : 'bg-zinc-300 dark:bg-zinc-700'
+        }`}
+      >
+        <span
+          className={`size-4 rounded-full bg-white shadow-sm transition-transform ${
+            checked ? 'translate-x-[18px]' : 'translate-x-0.5'
+          }`}
+        />
+      </button>
+    </div>
+  );
+}

--- a/apps/extensions/src/lib/i18n/en.ts
+++ b/apps/extensions/src/lib/i18n/en.ts
@@ -81,6 +81,7 @@ export const en = {
     animBounce: 'Bounce in',
     animStagger: 'Stagger (meta first, then message)',
     animFade: 'Fade in',
+    animTyping: 'Typewriter',
     animNone: 'No animation',
     orientation: 'Orientation',
     vertical: 'Vertical',

--- a/apps/extensions/src/lib/i18n/en.ts
+++ b/apps/extensions/src/lib/i18n/en.ts
@@ -13,6 +13,7 @@ export const en = {
       'Paste this URL as a Browser Source in OBS Studio, Streamlabs Desktop, XSplit, vMix, Lightstream, PRISM Live Studio, or any software that supports browser sources',
     themeToggle: 'Toggle color theme',
     languageToggle: 'Switch language',
+    moreInfo: 'More info',
   },
   home: {
     heroBadge: '100% Free · No Login Required · Instant Browser Source Setup',
@@ -59,7 +60,7 @@ export const en = {
     intro:
       'A customizable multi-chat widget and stream chat box overlay merging Twitch and Kick into a single feed with 7TV emotes and custom themes.',
     platforms: 'Platforms',
-    both: 'Both (Twitch & Kick)',
+    both: 'Both',
     twitch: 'Twitch',
     kick: 'Kick',
     twitchChannel: 'Twitch Channel',
@@ -68,7 +69,26 @@ export const en = {
     platformName: 'Platform Name',
     platformIcon: 'Platform Icon',
     platformHidden: 'Hide Platform',
-    styleSection: 'Style & Appearance (Customizable Stream Overlays)',
+    sectionChannel: 'Channel',
+    sectionAppearance: 'Appearance',
+    sectionMessages: 'Messages',
+    platformsTip:
+      'Pick which platforms to pull chat from. Select both to merge Twitch and Kick messages into a single feed.',
+    channelTip:
+      "Just type the channel name, not the full link. For twitch.tv/senchabot, that's senchabot.",
+    platformIndicatorTip:
+      'When both platforms are on, shows where each message came from: the platform name, its icon, or nothing.',
+    orientationTip:
+      'Vertical stacks messages on top of each other, like a classic chat box. Horizontal runs them side by side, great for a strip along the bottom of your screen.',
+    darkBackgroundTip:
+      'Adds a semi-transparent black background behind the widget. Makes text easier to read on bright scenes.',
+    sevenTvTip:
+      'Shows the custom and global emotes your channel added on 7TV as images. When off, they show up as plain text.',
+    badgesTip: 'Shows broadcaster, moderator, VIP and subscriber badges next to usernames.',
+    keepMessagesTip:
+      'Messages normally disappear after 30 seconds. Turn this on to keep them on screen, with new ones pushing older ones up.',
+    animationTip:
+      'Sets how new messages enter the screen. Animations get shorter automatically as chat speeds up.',
     font: 'Font',
     fontSystem: 'System Default',
     messageLayout: 'Message Layout',

--- a/apps/extensions/src/lib/i18n/en.ts
+++ b/apps/extensions/src/lib/i18n/en.ts
@@ -77,6 +77,7 @@ export const en = {
     layoutCompact: 'Compact (Twitch-like)',
     newMessageAnimation: 'New Message Animation',
     animSlide: 'Slide from right + fade',
+    animSmoothSlide: 'Smooth slide from right',
     animPop: 'Pop / scale-in',
     animBounce: 'Bounce in',
     animStagger: 'Stagger (meta first, then message)',
@@ -101,6 +102,9 @@ export const en = {
     boldMessages: 'Bold Messages',
     previewTitle: 'Widget Preview (Chat Box)',
     previewIframeTitle: 'Chat Widget Preview',
+    previewSpeed: 'Preview Chat Speed',
+    previewSpeedValue: '{rate} msg/s',
+    previewSpeedHint: 'Only changes the preview. Your widget URL stays the same.',
     previewHint: 'Live chat preview with animated message stream.',
     guideTitle: 'Streaming Software Chat Box Setup (OBS, Streamlabs, XSplit, etc.)',
     guideStep1:

--- a/apps/extensions/src/lib/i18n/en.ts
+++ b/apps/extensions/src/lib/i18n/en.ts
@@ -67,6 +67,7 @@ export const en = {
     platformIndicator: 'Platform Indicator',
     platformName: 'Platform Name',
     platformIcon: 'Platform Icon',
+    platformHidden: 'Hide Platform',
     styleSection: 'Style & Appearance (Customizable Stream Overlays)',
     font: 'Font',
     fontSystem: 'System Default',

--- a/apps/extensions/src/lib/i18n/tr.ts
+++ b/apps/extensions/src/lib/i18n/tr.ts
@@ -83,6 +83,7 @@ export const tr: typeof en = {
     animBounce: 'Zıplayarak gir',
     animStagger: 'Sıralı (önce bilgi, sonra mesaj)',
     animFade: 'Solayarak belir',
+    animTyping: 'Daktilo gibi yaz',
     animNone: 'Animasyon yok',
     orientation: 'Yön',
     vertical: 'Dikey',

--- a/apps/extensions/src/lib/i18n/tr.ts
+++ b/apps/extensions/src/lib/i18n/tr.ts
@@ -79,6 +79,7 @@ export const tr: typeof en = {
     layoutCompact: 'Kompakt (Twitch benzeri)',
     newMessageAnimation: 'Yeni Mesaj Animasyonu',
     animSlide: 'Sağdan kayarak gir + solma',
+    animSmoothSlide: 'Sağdan yumuşakça kayarak gir',
     animPop: 'Belirerek büyü / ölçeklen',
     animBounce: 'Zıplayarak gir',
     animStagger: 'Sıralı (önce bilgi, sonra mesaj)',
@@ -104,6 +105,9 @@ export const tr: typeof en = {
     boldMessages: 'Kalın Mesajlar',
     previewTitle: 'Widget Önizleme (Sohbet Kutusu)',
     previewIframeTitle: 'Sohbet Widget Önizleme',
+    previewSpeed: 'Önizleme Sohbet Hızı',
+    previewSpeedValue: '{rate} mesaj/sn',
+    previewSpeedHint: "Sadece önizlemeyi etkiler, widget URL'si değişmez.",
     previewHint: 'Animasyonlu mesaj akışıyla canlı sohbet önizlemesi.',
     guideTitle: 'Yayın Yazılımı Sohbet Kutusu Kurulumu (OBS, Streamlabs, XSplit vb.)',
     guideStep1:

--- a/apps/extensions/src/lib/i18n/tr.ts
+++ b/apps/extensions/src/lib/i18n/tr.ts
@@ -69,6 +69,7 @@ export const tr: typeof en = {
     platformIndicator: 'Platform Göstergesi',
     platformName: 'Platform Adı',
     platformIcon: 'Platform Simgesi',
+    platformHidden: 'Platformu Gizle',
     styleSection: 'Stil ve Görünüm (Özelleştirilebilir Yayın Kaplamaları)',
     font: 'Yazı Tipi',
     fontSystem: 'Sistem Varsayılanı',

--- a/apps/extensions/src/lib/i18n/tr.ts
+++ b/apps/extensions/src/lib/i18n/tr.ts
@@ -15,6 +15,7 @@ export const tr: typeof en = {
       "Bu URL'yi OBS Studio, Streamlabs Desktop, XSplit, vMix, Lightstream, PRISM Live Studio veya tarayıcı kaynağı destekleyen herhangi bir yazılımda Tarayıcı Kaynağı olarak yapıştır",
     themeToggle: 'Tema değiştir',
     languageToggle: 'Dil değiştir',
+    moreInfo: 'Daha fazla bilgi',
   },
   home: {
     heroBadge: '%100 Ücretsiz · Giriş Gerektirmez · Anında Tarayıcı Kaynağı Kurulumu',
@@ -61,7 +62,7 @@ export const tr: typeof en = {
     intro:
       "Twitch ve Kick'i 7TV emote'ları ve özel temalarla tek bir akışta birleştiren özelleştirilebilir çoklu sohbet widget'ı ve yayın sohbet kutusu kaplaması.",
     platforms: 'Platformlar',
-    both: 'İkisi (Twitch & Kick)',
+    both: 'İkisi',
     twitch: 'Twitch',
     kick: 'Kick',
     twitchChannel: 'Twitch Kanalı',
@@ -70,7 +71,26 @@ export const tr: typeof en = {
     platformName: 'Platform Adı',
     platformIcon: 'Platform Simgesi',
     platformHidden: 'Platformu Gizle',
-    styleSection: 'Stil ve Görünüm (Özelleştirilebilir Yayın Kaplamaları)',
+    sectionChannel: 'Kanal',
+    sectionAppearance: 'Görünüm',
+    sectionMessages: 'Mesajlar',
+    platformsTip:
+      'Sohbeti hangi platformlardan alacağını seç. İkisini seçersen Twitch ve Kick mesajları tek akışta birleşir.',
+    channelTip:
+      'Tam linki değil, sadece kanal adını yaz. Örneğin twitch.tv/senchabot için senchabot.',
+    platformIndicatorTip:
+      'İki platform birlikteyken her mesajın yanında nereden geldiğini gösterir: platform adı, simgesi ya da hiçbir şey.',
+    orientationTip:
+      'Dikeyde mesajlar alt alta dizilir, klasik sohbet kutusu gibi. Yatayda yan yana akar, ekranın altına şerit olarak koymak için ideal.',
+    darkBackgroundTip:
+      "Widget'ın arkasına yarı saydam siyah bir zemin koyar. Açık renkli sahnelerde yazıları okumayı kolaylaştırır.",
+    sevenTvTip:
+      "Kanalın 7TV'ye eklediği özel ve global emote'ları resim olarak gösterir. Kapalıyken bu emote'lar düz yazı olarak görünür.",
+    badgesTip: 'Kullanıcı adının yanında yayıncı, moderatör, VIP ve abone rozetlerini gösterir.',
+    keepMessagesTip:
+      'Mesajlar normalde 30 saniye sonra kaybolur. Bunu açarsan ekranda kalırlar, yeni gelenler eskileri yukarı iter.',
+    animationTip:
+      'Yeni mesajın ekrana nasıl gireceğini belirler. Sohbet hızlandıkça animasyonlar otomatik olarak kısalır.',
     font: 'Yazı Tipi',
     fontSystem: 'Sistem Varsayılanı',
     messageLayout: 'Mesaj Düzeni',

--- a/apps/extensions/src/routes/setup/chat-widget.tsx
+++ b/apps/extensions/src/routes/setup/chat-widget.tsx
@@ -125,7 +125,7 @@ function ChatWidgetSetup() {
   const [platforms, setPlatforms] = useState<"both" | "twitch" | "kick">(
     "both",
   );
-  const [platformDisplay, setPlatformDisplay] = useState<"name" | "icon">(
+  const [platformDisplay, setPlatformDisplay] = useState<"name" | "icon" | "none">(
     "icon",
   );
   const [sevenTv, setSevenTv] = useState(true);
@@ -372,11 +372,12 @@ function ChatWidgetSetup() {
                   <select
                     value={platformDisplay}
                     onChange={(e) =>
-                      setPlatformDisplay(e.target.value as "name" | "icon")
+                      setPlatformDisplay(e.target.value as "name" | "icon" | "none")
                     }
                     className="w-full rounded-md border border-zinc-300 bg-zinc-100 px-3 py-2.5 text-zinc-900 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500">
                     <option value="name">{t("chatWidget.platformName")}</option>
                     <option value="icon">{t("chatWidget.platformIcon")}</option>
+                    <option value="none">{t("chatWidget.platformHidden")}</option>
                   </select>
                 </div>
               )}

--- a/apps/extensions/src/routes/setup/chat-widget.tsx
+++ b/apps/extensions/src/routes/setup/chat-widget.tsx
@@ -1,106 +1,112 @@
-import { Breadcrumb } from "#/components/breadcrumb";
-import { YoutubeTutorial } from "#/components/youtube-tutorial";
-import { useI18n } from "#/lib/i18n";
-import { getLocaleLinks } from "#/lib/i18n/seo";
-import { createFileRoute, Link } from "@tanstack/react-router";
-import { useDeferredValue, useEffect, useMemo, useState } from "react";
+import { createFileRoute, Link } from '@tanstack/react-router';
+import { type ReactNode, useDeferredValue, useEffect, useId, useMemo, useState } from 'react';
+import { Breadcrumb } from '#/components/breadcrumb';
+import { FieldLabel } from '#/components/ui/field-label';
+import { InfoTip } from '#/components/ui/info-tip';
+import { NumberField } from '#/components/ui/number-field';
+import { SegmentedControl, type SegmentedOption } from '#/components/ui/segmented-control';
+import { Select, type SelectOption } from '#/components/ui/select';
+import { Switch } from '#/components/ui/switch';
+import { YoutubeTutorial } from '#/components/youtube-tutorial';
+import { useI18n } from '#/lib/i18n';
+import { getLocaleLinks } from '#/lib/i18n/seo';
 
-export const Route = createFileRoute("/setup/chat-widget")({
+export const Route = createFileRoute('/setup/chat-widget')({
   head: () => ({
     meta: [
       {
         title:
-          "Free Multi-Chat Widget & Stream Chat Box for Twitch & Kick (No Login Required) — Chat Box | Senchabot",
+          'Free Multi-Chat Widget & Stream Chat Box for Twitch & Kick (No Login Required) — Chat Box | Senchabot',
       },
       {
-        name: "description",
+        name: 'description',
         content:
-          "Combine Twitch and Kick chat into one free multi-chat widget and stream chat box overlay. 100% Free & No Login Required. Supports 7TV emotes, badges, custom fonts, animations, and customizable stream overlays for OBS Studio, Streamlabs Desktop, XSplit, vMix, Lightstream, PRISM Live Studio, or any software that supports browser sources.",
+          'Combine Twitch and Kick chat into one free multi-chat widget and stream chat box overlay. 100% Free & No Login Required. Supports 7TV emotes, badges, custom fonts, animations, and customizable stream overlays for OBS Studio, Streamlabs Desktop, XSplit, vMix, Lightstream, PRISM Live Studio, or any software that supports browser sources.',
       },
       {
-        name: "keywords",
+        name: 'keywords',
         content:
-          "chat box, stream chat box, multi-chat widgets, customizable stream overlays, stream tools, free twitch kick chat overlay, multi-stream chat overlay no login, unified chat widget free, combined chat overlay obs, streamlabs chat box, xsplit chat widget, cross-platform stream chat free",
+          'chat box, stream chat box, multi-chat widgets, customizable stream overlays, stream tools, free twitch kick chat overlay, multi-stream chat overlay no login, unified chat widget free, combined chat overlay obs, streamlabs chat box, xsplit chat widget, cross-platform stream chat free',
       },
       {
-        property: "og:title",
+        property: 'og:title',
         content:
-          "Free Multi-Chat Widget & Stream Chat Box for Twitch & Kick (No Login Required) — Chat Box | Senchabot",
+          'Free Multi-Chat Widget & Stream Chat Box for Twitch & Kick (No Login Required) — Chat Box | Senchabot',
       },
       {
-        property: "og:description",
+        property: 'og:description',
         content:
-          "100% Free multi-chat widget and stream chat box overlay merging Twitch and Kick into a single feed. No login or account required. 7TV emotes and badges included.",
+          '100% Free multi-chat widget and stream chat box overlay merging Twitch and Kick into a single feed. No login or account required. 7TV emotes and badges included.',
       },
-      { property: "og:type", content: "website" },
+      { property: 'og:type', content: 'website' },
       {
-        property: "og:url",
-        content: "https://extensions.senchabot.com/setup/chat-widget",
+        property: 'og:url',
+        content: 'https://extensions.senchabot.com/setup/chat-widget',
       },
       {
-        property: "og:image",
-        content: "https://extensions.senchabot.com/senchabot-logo.svg",
+        property: 'og:image',
+        content: 'https://extensions.senchabot.com/senchabot-logo.svg',
       },
-      { name: "twitter:card", content: "summary" },
+      { name: 'twitter:card', content: 'summary' },
       {
-        name: "twitter:title",
+        name: 'twitter:title',
+        content: 'Free Multi-Chat Widget & Stream Chat Box for Twitch & Kick (No Login Required)',
+      },
+      {
+        name: 'twitter:description',
         content:
-          "Free Multi-Chat Widget & Stream Chat Box for Twitch & Kick (No Login Required)",
+          'Combine Twitch and Kick chat in OBS Studio, Streamlabs Desktop, XSplit, or any software supporting browser sources. Zero login required. 100% Free with 7TV emotes and badge support.',
       },
       {
-        name: "twitter:description",
-        content:
-          "Combine Twitch and Kick chat in OBS Studio, Streamlabs Desktop, XSplit, or any software supporting browser sources. Zero login required. 100% Free with 7TV emotes and badge support.",
+        name: 'twitter:image',
+        content: 'https://extensions.senchabot.com/senchabot-logo.svg',
       },
       {
-        name: "twitter:image",
-        content: "https://extensions.senchabot.com/senchabot-logo.svg",
-      },
-      {
-        "script:ld+json": {
-          "@context": "https://schema.org",
-          "@type": "WebApplication",
-          name: "Chat Box - Free Multi-Chat Widget & Stream Chat Box",
+        'script:ld+json': {
+          '@context': 'https://schema.org',
+          '@type': 'WebApplication',
+          name: 'Chat Box - Free Multi-Chat Widget & Stream Chat Box',
           description:
-            "A free customizable multi-chat widget and stream chat box overlay that merges Twitch and Kick chat into a single on-stream feed with 7TV emotes, badges, and customizable themes.",
-          url: "https://extensions.senchabot.com/setup/chat-widget",
-          applicationCategory: "MultimediaApplication",
-          operatingSystem: "All, OBS Studio, Streamlabs Desktop, XSplit Broadcaster, vMix, Lightstream, PRISM Live Studio, Twitch Studio, Meld Studio, Wirecast, Browser Source compatible",
+            'A free customizable multi-chat widget and stream chat box overlay that merges Twitch and Kick chat into a single on-stream feed with 7TV emotes, badges, and customizable themes.',
+          url: 'https://extensions.senchabot.com/setup/chat-widget',
+          applicationCategory: 'MultimediaApplication',
+          operatingSystem:
+            'All, OBS Studio, Streamlabs Desktop, XSplit Broadcaster, vMix, Lightstream, PRISM Live Studio, Twitch Studio, Meld Studio, Wirecast, Browser Source compatible',
           isAccessibleForFree: true,
           offers: {
-            "@type": "Offer",
-            price: "0",
-            priceCurrency: "USD",
-            description: "100% Free, No Login Required",
+            '@type': 'Offer',
+            price: '0',
+            priceCurrency: 'USD',
+            description: '100% Free, No Login Required',
           },
         },
       },
       {
-        "script:ld+json": {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
+        'script:ld+json': {
+          '@context': 'https://schema.org',
+          '@type': 'FAQPage',
           mainEntity: [
             {
-              "@type": "Question",
-              name: "Is this multi-chat widget and stream chat box completely free?",
+              '@type': 'Question',
+              name: 'Is this multi-chat widget and stream chat box completely free?',
               acceptedAnswer: {
-                "@type": "Answer",
-                text: "Yes, Chat Box is 100% free and open-source with no subscription fees, account sign-ups, or watermarks.",
+                '@type': 'Answer',
+                text: 'Yes, Chat Box is 100% free and open-source with no subscription fees, account sign-ups, or watermarks.',
               },
             },
             {
-              "@type": "Question",
-              name: "Does the chat box support 7TV emotes?",
+              '@type': 'Question',
+              name: 'Does the chat box support 7TV emotes?',
               acceptedAnswer: {
-                "@type": "Answer",
-                text: "Yes, 7TV custom channel emotes and animated emotes are supported automatically without extra extensions.",
+                '@type': 'Answer',
+                text: 'Yes, 7TV custom channel emotes and animated emotes are supported automatically without extra extensions.',
               },
             },
           ],
         },
       },
     ],
-    links: getLocaleLinks("/setup/chat-widget"),
+    links: getLocaleLinks('/setup/chat-widget'),
   }),
   component: ChatWidgetSetup,
 });
@@ -108,42 +114,117 @@ export const Route = createFileRoute("/setup/chat-widget")({
 // Messages per second for the mock preview only; index 0 keeps the widget's default mock pace.
 const PREVIEW_RATES = [0.3, 0.5, 1, 2, 3, 5, 10, 15, 20];
 
+type Platforms = 'both' | 'twitch' | 'kick';
+type PlatformDisplay = 'name' | 'icon' | 'none';
+type Font = 'inter' | 'roboto' | 'nunito' | 'mono' | 'serif' | 'system';
+type Layout = 'inline' | 'stacked' | 'card' | 'compact';
+type Orientation = 'vertical' | 'horizontal';
+type Animation = 'slide' | 'smooth' | 'pop' | 'bounce' | 'stagger' | 'fade' | 'typing' | 'none';
+
+interface Settings {
+  platforms: Platforms;
+  platformDisplay: PlatformDisplay;
+  font: Font;
+  fontSize: string;
+  layout: Layout;
+  orientation: Orientation;
+  animation: Animation;
+  background: boolean;
+  bgOpacity: string;
+  itemBackground: boolean;
+  platformAccent: boolean;
+  boldUsernames: boolean;
+  boldMessages: boolean;
+  sevenTv: boolean;
+  badges: boolean;
+  timestamp: boolean;
+  keep: boolean;
+}
+
+// Mirrors the widget's own defaults, so only changed settings end up in the URL.
+const DEFAULT_SETTINGS: Settings = {
+  platforms: 'both',
+  platformDisplay: 'icon',
+  font: 'inter',
+  fontSize: '18',
+  layout: 'inline',
+  orientation: 'vertical',
+  animation: 'slide',
+  background: false,
+  bgOpacity: '0.5',
+  itemBackground: false,
+  platformAccent: false,
+  boldUsernames: false,
+  boldMessages: false,
+  sevenTv: true,
+  badges: true,
+  timestamp: false,
+  keep: false,
+};
+
+function buildWidgetParams(settings: Settings, twitchChannel: string, kickChannel: string) {
+  const params = new URLSearchParams();
+  const twitch = twitchChannel.trim().toLowerCase();
+  const kick = kickChannel.trim().toLowerCase();
+  if (settings.platforms !== 'kick' && twitch) params.append('twitch', twitch);
+  if (settings.platforms !== 'twitch' && kick) params.append('kick', kick);
+  if (!settings.sevenTv) params.append('sevenTv', 'false');
+  if (!settings.badges) params.append('badges', 'false');
+  // An emptied field would otherwise reach the widget as fontSize=0.
+  if (Number(settings.fontSize) > 0 && settings.fontSize !== DEFAULT_SETTINGS.fontSize)
+    params.append('fontSize', settings.fontSize);
+  if (settings.background) {
+    params.append('background', 'true');
+    if (settings.bgOpacity !== DEFAULT_SETTINGS.bgOpacity)
+      params.append('bgOpacity', settings.bgOpacity);
+  }
+  if (settings.itemBackground) params.append('itemBackground', 'true');
+  if (settings.platformAccent) params.append('platformAccent', 'true');
+  if (settings.boldUsernames) params.append('boldUsernames', 'true');
+  if (settings.boldMessages) params.append('boldMessages', 'true');
+  if (settings.orientation !== DEFAULT_SETTINGS.orientation)
+    params.append('orientation', settings.orientation);
+  if (
+    settings.platforms === 'both' &&
+    settings.platformDisplay !== DEFAULT_SETTINGS.platformDisplay
+  )
+    params.append('platformDisplay', settings.platformDisplay);
+  if (settings.timestamp) params.append('timestamp', 'true');
+  if (settings.keep) params.append('keep', 'true');
+  if (settings.font !== DEFAULT_SETTINGS.font) params.append('font', settings.font);
+  if (settings.layout !== DEFAULT_SETTINGS.layout) params.append('layout', settings.layout);
+  if (settings.animation !== DEFAULT_SETTINGS.animation)
+    params.append('animation', settings.animation);
+  return params;
+}
+
+const PANEL_CLASS =
+  'rounded-xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900';
+const INPUT_CLASS =
+  'h-9 w-full rounded-md border border-zinc-300 bg-zinc-100 px-3 text-sm text-zinc-900 placeholder-zinc-500 transition-colors focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white';
+const RANGE_CLASS =
+  'h-2 w-full cursor-pointer appearance-none rounded-lg bg-zinc-300 accent-green-500 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-zinc-700';
+
+function SettingsGroup({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="space-y-3 border-t border-zinc-200 pt-3 first:border-t-0 first:pt-0 dark:border-zinc-800">
+      <h2 className="text-[11px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
 function ChatWidgetSetup() {
   const { locale, t } = useI18n();
-  const [twitchChannel, setTwitchChannel] = useState("");
-  const [kickChannel, setKickChannel] = useState("");
-  const [fontSize, setFontSize] = useState("18");
-  const [hasBackground, setHasBackground] = useState(false);
-  const [itemBackground, setItemBackground] = useState(false);
-  const [platformAccent, setPlatformAccent] = useState(false);
-  const [boldUsernames, setBoldUsernames] = useState(false);
-  const [boldMessages, setBoldMessages] = useState(false);
-  const [backgroundOpacity, setBackgroundOpacity] = useState("0.5");
-  const [orientation, setOrientation] = useState<"vertical" | "horizontal">(
-    "vertical",
-  );
-  const [platforms, setPlatforms] = useState<"both" | "twitch" | "kick">(
-    "both",
-  );
-  const [platformDisplay, setPlatformDisplay] = useState<"name" | "icon" | "none">(
-    "icon",
-  );
-  const [sevenTv, setSevenTv] = useState(true);
-  const [badges, setBadges] = useState(true);
-  const [showTimestamp, setShowTimestamp] = useState(false);
-  const [keepMessages, setKeepMessages] = useState(false);
-  const [font, setFont] = useState<
-    "inter" | "roboto" | "nunito" | "mono" | "serif" | "system"
-  >("inter");
-  const [layout, setLayout] = useState<
-    "inline" | "stacked" | "card" | "compact"
-  >("inline");
-  const [animation, setAnimation] = useState<
-    "slide" | "smooth" | "pop" | "bounce" | "stagger" | "fade" | "typing" | "none"
-  >("slide");
+  const [twitchChannel, setTwitchChannel] = useState('');
+  const [kickChannel, setKickChannel] = useState('');
+  const [settings, setSettings] = useState(DEFAULT_SETTINGS);
   const [previewRateIndex, setPreviewRateIndex] = useState(0);
   const [copied, setCopied] = useState(false);
   const [mounted, setMounted] = useState(false);
+  const id = useId();
 
   useEffect(() => {
     setMounted(true);
@@ -152,113 +233,24 @@ function ChatWidgetSetup() {
   const deferredTwitch = useDeferredValue(twitchChannel);
   const deferredKick = useDeferredValue(kickChannel);
 
-  const widgetUrl = useMemo(() => {
-    if (typeof window === "undefined") return "";
-    const params = new URLSearchParams();
-    if (platforms === "both" || platforms === "twitch")
-      if (twitchChannel.trim()) params.append("twitch", twitchChannel.trim().toLowerCase());
-    if (platforms === "both" || platforms === "kick")
-      if (kickChannel.trim()) params.append("kick", kickChannel.trim().toLowerCase());
-    if (!sevenTv) params.append("sevenTv", "false");
-    if (!badges) params.append("badges", "false");
-    if (fontSize !== "18") params.append("fontSize", fontSize);
-    if (hasBackground) {
-      params.append("background", "true");
-      if (backgroundOpacity !== "0.5") params.append("bgOpacity", backgroundOpacity);
-    }
-    if (itemBackground) params.append("itemBackground", "true");
-    if (platformAccent) params.append("platformAccent", "true");
-    if (boldUsernames) params.append("boldUsernames", "true");
-    if (boldMessages) params.append("boldMessages", "true");
-    if (orientation !== "vertical") params.append("orientation", orientation);
-    if (platforms === "both" && platformDisplay !== "icon")
-      params.append("platformDisplay", platformDisplay);
-    if (showTimestamp) params.append("timestamp", "true");
-    if (keepMessages) params.append("keep", "true");
-    if (font !== "inter") params.append("font", font);
-    if (layout !== "inline") params.append("layout", layout);
-    if (animation !== "slide") params.append("animation", animation);
+  const update = <K extends keyof Settings>(key: K, value: Settings[K]) =>
+    setSettings((current) => ({ ...current, [key]: value }));
 
-    if (!twitchChannel.trim() && !kickChannel.trim()) {
-      return "";
-    }
+  const widgetUrl = useMemo(() => {
+    if (!mounted) return '';
+    const params = buildWidgetParams(settings, twitchChannel, kickChannel);
+    if (!params.has('twitch') && !params.has('kick')) return '';
     return `${window.location.origin}/widgets/chat-widget?${params.toString()}`;
-  }, [
-    twitchChannel,
-    kickChannel,
-    sevenTv,
-    badges,
-    fontSize,
-    hasBackground,
-    backgroundOpacity,
-    itemBackground,
-    platformAccent,
-    boldUsernames,
-    boldMessages,
-    orientation,
-    platforms,
-    platformDisplay,
-    showTimestamp,
-    keepMessages,
-    font,
-    layout,
-    animation,
-  ]);
+  }, [mounted, settings, twitchChannel, kickChannel]);
 
   const previewUrl = useMemo(() => {
-    if (typeof window === "undefined") return "";
-    const params = new URLSearchParams();
-    if (platforms === "both" || platforms === "twitch")
-      if (deferredTwitch.trim()) params.append("twitch", deferredTwitch.trim().toLowerCase());
-    if (platforms === "both" || platforms === "kick")
-      if (deferredKick.trim()) params.append("kick", deferredKick.trim().toLowerCase());
-    if (!sevenTv) params.append("sevenTv", "false");
-    if (!badges) params.append("badges", "false");
-    if (fontSize !== "18") params.append("fontSize", fontSize);
-    if (hasBackground) {
-      params.append("background", "true");
-      if (backgroundOpacity !== "0.5") params.append("bgOpacity", backgroundOpacity);
-    }
-    if (itemBackground) params.append("itemBackground", "true");
-    if (platformAccent) params.append("platformAccent", "true");
-    if (boldUsernames) params.append("boldUsernames", "true");
-    if (boldMessages) params.append("boldMessages", "true");
-    if (orientation !== "vertical") params.append("orientation", orientation);
-    if (platforms === "both" && platformDisplay !== "icon")
-      params.append("platformDisplay", platformDisplay);
-    if (showTimestamp) params.append("timestamp", "true");
-    if (keepMessages) params.append("keep", "true");
-    if (font !== "inter") params.append("font", font);
-    if (layout !== "inline") params.append("layout", layout);
-    if (animation !== "slide") params.append("animation", animation);
-    params.append("mock", "true");
-    if (previewRateIndex > 0)
-      params.append("mockRate", String(PREVIEW_RATES[previewRateIndex]));
-    params.append("lang", locale);
+    if (!mounted) return '';
+    const params = buildWidgetParams(settings, deferredTwitch, deferredKick);
+    params.append('mock', 'true');
+    if (previewRateIndex > 0) params.append('mockRate', String(PREVIEW_RATES[previewRateIndex]));
+    params.append('lang', locale);
     return `${window.location.origin}/widgets/chat-widget?${params.toString()}`;
-  }, [
-    deferredTwitch,
-    deferredKick,
-    sevenTv,
-    badges,
-    fontSize,
-    hasBackground,
-    backgroundOpacity,
-    itemBackground,
-    platformAccent,
-    boldUsernames,
-    boldMessages,
-    orientation,
-    platforms,
-    platformDisplay,
-    showTimestamp,
-    keepMessages,
-    font,
-    layout,
-    animation,
-    previewRateIndex,
-    locale,
-  ]);
+  }, [mounted, settings, deferredTwitch, deferredKick, previewRateIndex, locale]);
 
   const handleCopy = async () => {
     if (widgetUrl) {
@@ -268,507 +260,384 @@ function ChatWidgetSetup() {
     }
   };
 
-  const isFormValid =
-    (platforms !== "kick" && twitchChannel.length > 0) ||
-    (platforms !== "twitch" && kickChannel.length > 0);
+  const platformOptions: SegmentedOption<Platforms>[] = [
+    { value: 'both', label: t('chatWidget.both') },
+    { value: 'twitch', label: t('chatWidget.twitch') },
+    { value: 'kick', label: t('chatWidget.kick') },
+  ];
+  const platformDisplayOptions: SelectOption<PlatformDisplay>[] = [
+    { value: 'name', label: t('chatWidget.platformName') },
+    { value: 'icon', label: t('chatWidget.platformIcon') },
+    { value: 'none', label: t('chatWidget.platformHidden') },
+  ];
+  const fontOptions: SelectOption<Font>[] = [
+    { value: 'inter', label: 'Inter' },
+    { value: 'roboto', label: 'Roboto' },
+    { value: 'nunito', label: 'Nunito' },
+    { value: 'mono', label: 'JetBrains Mono' },
+    { value: 'serif', label: 'Source Serif 4' },
+    { value: 'system', label: t('chatWidget.fontSystem') },
+  ];
+  const orientationOptions: SegmentedOption<Orientation>[] = [
+    { value: 'vertical', label: t('chatWidget.vertical') },
+    { value: 'horizontal', label: t('chatWidget.horizontal') },
+  ];
+  const layoutOptions: SelectOption<Layout>[] = [
+    { value: 'inline', label: t('chatWidget.layoutInline') },
+    { value: 'stacked', label: t('chatWidget.layoutStacked') },
+    { value: 'card', label: t('chatWidget.layoutCard') },
+    { value: 'compact', label: t('chatWidget.layoutCompact') },
+  ];
+  const animationOptions: SelectOption<Animation>[] = [
+    { value: 'slide', label: t('chatWidget.animSlide') },
+    { value: 'smooth', label: t('chatWidget.animSmoothSlide') },
+    { value: 'pop', label: t('chatWidget.animPop') },
+    { value: 'bounce', label: t('chatWidget.animBounce') },
+    { value: 'stagger', label: t('chatWidget.animStagger') },
+    { value: 'fade', label: t('chatWidget.animFade') },
+    { value: 'typing', label: t('chatWidget.animTyping') },
+    { value: 'none', label: t('chatWidget.animNone') },
+  ];
 
   return (
-    <div className="min-h-screen bg-zinc-50 text-zinc-900 font-sans p-6 pt-12 dark:bg-zinc-950 dark:text-zinc-100">
-      <div className="max-w-6xl mx-auto">
-        <div className="flex flex-col lg:flex-row items-center lg:items-start justify-center gap-8 mb-12">
-          {/* Left: Configuration Panel */}
-          <div className="w-full max-w-md lg:shrink-0 rounded-xl bg-white p-6 md:p-8 shadow-xl border border-zinc-200 dark:bg-zinc-900 dark:border-zinc-800">
-            <div className="mb-4">
-              <Breadcrumb
-                items={[
-                  { label: t("common.home"), href: "/" },
-                  { label: t("chatWidget.breadcrumb") },
-                ]}
-              />
-            </div>
-            <div className="mb-6 flex justify-center">
-              <Link
-                to="/"
-                className="relative inline-flex select-none flex-col items-center gap-2 text-xl font-semibold tracking-wide text-zinc-900 transition-opacity hover:opacity-75 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500 dark:text-white">
-                <div className="inline-flex size-10 shrink-0">
-                  <img
-                    src="/senchabot-logo.svg"
-                    alt="Senchabot"
-                    width={40}
-                    height={40}
-                  />
-                </div>
-              </Link>
-            </div>
-
-            <div className="flex justify-center mb-3">
-              <span className="inline-flex items-center gap-1.5 rounded-full bg-green-500/10 px-3 py-0.5 text-xs font-medium text-green-700 border border-green-500/20 dark:text-green-400">
-                {t("common.freeBadge")}
+    <div className="min-h-screen bg-zinc-50 font-sans text-zinc-900 dark:bg-zinc-950 dark:text-zinc-100">
+      <div className="mx-auto flex max-w-6xl flex-col px-4 py-4 lg:h-dvh lg:min-h-[640px]">
+        <header className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-2 pr-32">
+          <Link
+            to="/"
+            className="shrink-0 rounded-md transition-opacity hover:opacity-75 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500"
+          >
+            <img src="/senchabot-logo.svg" alt="Senchabot" width={36} height={36} />
+          </Link>
+          <div className="min-w-0">
+            <Breadcrumb
+              items={[
+                { label: t('common.home'), href: '/' },
+                { label: t('chatWidget.breadcrumb') },
+              ]}
+            />
+            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1">
+              <h1 className="text-xl font-bold text-zinc-900 dark:text-white">
+                {t('chatWidget.title')}
+              </h1>
+              <span className="rounded-full border border-green-500/20 bg-green-500/10 px-2.5 py-0.5 text-xs font-medium text-green-700 dark:text-green-400">
+                {t('common.freeBadge')}
               </span>
             </div>
+          </div>
+        </header>
 
-            <h1 className="mb-4 text-2xl font-bold text-center text-zinc-900 dark:text-white">
-              {t("chatWidget.title")}
-            </h1>
-
-            <div className="space-y-4">
-              <p className="text-xs text-zinc-600 bg-zinc-100 p-3 rounded-md border border-zinc-200 leading-relaxed dark:text-zinc-400 dark:bg-zinc-800/40 dark:border-zinc-800">
-                {t("chatWidget.intro")}
-              </p>
-
-              <YoutubeTutorial />
-
-              <div>
-                <label className="mb-1 block text-sm font-medium text-zinc-600 dark:text-zinc-400">
-                  {t("chatWidget.platforms")}
-                </label>
-                <select
-                  value={platforms}
-                  onChange={(e) =>
-                    setPlatforms(e.target.value as "both" | "twitch" | "kick")
-                  }
-                  className="w-full rounded-md border border-zinc-300 bg-zinc-100 px-3 py-2.5 text-zinc-900 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500">
-                  <option value="both">{t("chatWidget.both")}</option>
-                  <option value="twitch">{t("chatWidget.twitch")}</option>
-                  <option value="kick">{t("chatWidget.kick")}</option>
-                </select>
-              </div>
-
-              {(platforms === "both" || platforms === "twitch") && (
-                <div>
-                  <label className="mb-1 block text-sm font-medium text-zinc-600 dark:text-zinc-400">
-                    {t("chatWidget.twitchChannel")}
-                  </label>
-                  <input
-                    type="text"
-                    value={twitchChannel}
-                    onChange={(e) => setTwitchChannel(e.target.value)}
-                    placeholder={t("common.channelPlaceholder")}
-                    className="w-full rounded-md border border-zinc-300 bg-zinc-100 px-3 py-2 text-zinc-900 placeholder-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500"
-                  />
-                </div>
-              )}
-
-              {(platforms === "both" || platforms === "kick") && (
-                <div>
-                  <label className="mb-1 block text-sm font-medium text-zinc-600 dark:text-zinc-400">
-                    {t("chatWidget.kickChannel")}
-                  </label>
-                  <input
-                    type="text"
-                    value={kickChannel}
-                    onChange={(e) => setKickChannel(e.target.value)}
-                    placeholder={t("common.channelPlaceholder")}
-                    className="w-full rounded-md border border-zinc-300 bg-zinc-100 px-3 py-2 text-zinc-900 placeholder-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500"
-                  />
-                </div>
-              )}
-
-              {platforms === "both" && (
-                <div>
-                  <label className="mb-1 block text-sm font-medium text-zinc-600 dark:text-zinc-400">
-                    {t("chatWidget.platformIndicator")}
-                  </label>
-                  <select
-                    value={platformDisplay}
-                    onChange={(e) =>
-                      setPlatformDisplay(e.target.value as "name" | "icon" | "none")
-                    }
-                    className="w-full rounded-md border border-zinc-300 bg-zinc-100 px-3 py-2.5 text-zinc-900 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500">
-                    <option value="name">{t("chatWidget.platformName")}</option>
-                    <option value="icon">{t("chatWidget.platformIcon")}</option>
-                    <option value="none">{t("chatWidget.platformHidden")}</option>
-                  </select>
-                </div>
-              )}
-
-              <details className="rounded-md border border-zinc-200 bg-zinc-100/60 open:bg-zinc-100 transition-colors dark:border-zinc-800 dark:bg-zinc-900/40 dark:open:bg-zinc-900/60">
-                <summary className="cursor-pointer select-none px-3 py-2 text-sm font-medium text-zinc-700 hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-white">
-                  {t("chatWidget.styleSection")}
-                </summary>
-                <div className="space-y-4 border-t border-zinc-200 p-3 dark:border-zinc-800">
+        <div className="grid gap-5 lg:min-h-0 lg:flex-1 lg:grid-cols-[34rem_minmax(0,1fr)]">
+          {/* Scrolling happens on the inner box, so on short screens content is clipped inside the
+              panel padding instead of running under the bottom edge; its p-1 keeps focus rings unclipped. */}
+          <div className={`${PANEL_CLASS} p-4 lg:flex lg:min-h-0 lg:flex-col`}>
+            <div className="space-y-3 p-1 lg:min-h-0 lg:flex-1 lg:overflow-y-auto">
+              <SettingsGroup title={t('chatWidget.sectionChannel')}>
+                <div className="grid gap-3 sm:grid-cols-2">
                   <div>
-                    <label className="mb-1 block text-sm font-medium text-zinc-600 dark:text-zinc-400">
-                      {t("chatWidget.font")}
-                    </label>
-                    <select
-                      value={font}
-                      onChange={(e) =>
-                        setFont(
-                          e.target.value as
-                            | "inter"
-                            | "roboto"
-                            | "nunito"
-                            | "mono"
-                            | "serif"
-                            | "system",
-                        )
-                      }
-                      className="w-full rounded-md border border-zinc-300 bg-zinc-100 px-3 py-2.5 text-zinc-900 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500">
-                      <option value="inter">Inter</option>
-                      <option value="roboto">Roboto</option>
-                      <option value="nunito">Nunito</option>
-                      <option value="mono">JetBrains Mono</option>
-                      <option value="serif">Source Serif 4</option>
-                      <option value="system">{t("chatWidget.fontSystem")}</option>
-                    </select>
-                  </div>
-
-                  <div>
-                    <label className="mb-1 block text-sm font-medium text-zinc-600 dark:text-zinc-400">
-                      {t("chatWidget.messageLayout")}
-                    </label>
-                    <select
-                      value={layout}
-                      onChange={(e) =>
-                        setLayout(
-                          e.target.value as
-                            | "inline"
-                            | "stacked"
-                            | "card"
-                            | "compact",
-                        )
-                      }
-                      className="w-full rounded-md border border-zinc-300 bg-zinc-100 px-3 py-2.5 text-zinc-900 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500">
-                      <option value="inline">{t("chatWidget.layoutInline")}</option>
-                      <option value="stacked">{t("chatWidget.layoutStacked")}</option>
-                      <option value="card">{t("chatWidget.layoutCard")}</option>
-                      <option value="compact">{t("chatWidget.layoutCompact")}</option>
-                    </select>
-                  </div>
-
-                  <div>
-                    <label className="mb-1 block text-sm font-medium text-zinc-600 dark:text-zinc-400">
-                      {t("chatWidget.newMessageAnimation")}
-                    </label>
-                    <select
-                      value={animation}
-                      onChange={(e) =>
-                        setAnimation(
-                          e.target.value as
-                            | "slide"
-                            | "smooth"
-                            | "pop"
-                            | "bounce"
-                            | "stagger"
-                            | "fade"
-                            | "typing"
-                            | "none",
-                        )
-                      }
-                      className="w-full rounded-md border border-zinc-300 bg-zinc-100 px-3 py-2.5 text-zinc-900 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500">
-                      <option value="slide">{t("chatWidget.animSlide")}</option>
-                      <option value="smooth">{t("chatWidget.animSmoothSlide")}</option>
-                      <option value="pop">{t("chatWidget.animPop")}</option>
-                      <option value="bounce">{t("chatWidget.animBounce")}</option>
-                      <option value="stagger">
-                        {t("chatWidget.animStagger")}
-                      </option>
-                      <option value="fade">{t("chatWidget.animFade")}</option>
-                      <option value="typing">{t("chatWidget.animTyping")}</option>
-                      <option value="none">{t("chatWidget.animNone")}</option>
-                    </select>
-                  </div>
-                </div>
-              </details>
-
-              <div className="flex gap-4">
-                <div className="flex-1 max-w-[150px]">
-                  <label className="mb-1 block text-sm font-medium text-zinc-600 dark:text-zinc-400">
-                    {t("chatWidget.orientation")}
-                  </label>
-                  <select
-                    value={orientation}
-                    onChange={(e) =>
-                      setOrientation(
-                        e.target.value as "vertical" | "horizontal",
-                      )
-                    }
-                    className="w-full rounded-md border border-zinc-300 bg-zinc-100 px-3 py-2.5 text-zinc-900 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500">
-                    <option value="vertical">{t("chatWidget.vertical")}</option>
-                    <option value="horizontal">{t("chatWidget.horizontal")}</option>
-                  </select>
-                </div>
-
-                <div className="flex-1">
-                  <label className="mb-1 block text-sm font-medium text-zinc-600 dark:text-zinc-400">
-                    {t("chatWidget.fontSize")}
-                  </label>
-                  <input
-                    type="number"
-                    value={fontSize}
-                    onChange={(e) => setFontSize(e.target.value)}
-                    className="w-full rounded-md border border-zinc-300 bg-zinc-100 px-3 py-2 text-zinc-900 placeholder-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500"
-                  />
-                </div>
-
-                <div className="flex-1 flex flex-col justify-end pb-2">
-                  <label className="flex items-center space-x-2 text-zinc-900 cursor-pointer dark:text-white">
-                    <input
-                      type="checkbox"
-                      checked={hasBackground}
-                      onChange={(e) => setHasBackground(e.target.checked)}
-                      className="rounded border-zinc-300 bg-zinc-100 text-green-500 focus:ring-green-500 dark:border-zinc-700 dark:bg-zinc-800"
+                    <FieldLabel id={`${id}-platforms`} tip={t('chatWidget.platformsTip')}>
+                      {t('chatWidget.platforms')}
+                    </FieldLabel>
+                    <SegmentedControl
+                      labelledBy={`${id}-platforms`}
+                      value={settings.platforms}
+                      onChange={(value) => update('platforms', value)}
+                      options={platformOptions}
                     />
-                    <span className="text-sm">{t("chatWidget.darkBackground")}</span>
-                  </label>
-                </div>
-              </div>
-
-              <div>
-                <label className="flex items-center space-x-2 text-zinc-900 cursor-pointer dark:text-white">
-                  <input
-                    type="checkbox"
-                    checked={sevenTv}
-                    onChange={(e) => setSevenTv(e.target.checked)}
-                    className="rounded border-zinc-300 bg-zinc-100 text-green-500 focus:ring-green-500 dark:border-zinc-700 dark:bg-zinc-800"
-                  />
-                  <span className="text-sm">{t("chatWidget.sevenTvEmotes")}</span>
-                </label>
-              </div>
-
-              <div>
-                <label className="flex items-center space-x-2 text-zinc-900 cursor-pointer dark:text-white">
-                  <input
-                    type="checkbox"
-                    checked={badges}
-                    onChange={(e) => setBadges(e.target.checked)}
-                    className="rounded border-zinc-300 bg-zinc-100 text-green-500 focus:ring-green-500 dark:border-zinc-700 dark:bg-zinc-800"
-                  />
-                  <span className="text-sm">{t("chatWidget.showBadges")}</span>
-                </label>
-              </div>
-
-              <div>
-                <label className="flex items-center space-x-2 text-zinc-900 cursor-pointer dark:text-white">
-                  <input
-                    type="checkbox"
-                    checked={showTimestamp}
-                    onChange={(e) => setShowTimestamp(e.target.checked)}
-                    className="rounded border-zinc-300 bg-zinc-100 text-green-500 focus:ring-green-500 dark:border-zinc-700 dark:bg-zinc-800"
-                  />
-                  <span className="text-sm">{t("chatWidget.showMessageTime")}</span>
-                </label>
-              </div>
-
-              <div>
-                <label className="flex items-center space-x-2 text-zinc-900 cursor-pointer dark:text-white">
-                  <input
-                    type="checkbox"
-                    checked={keepMessages}
-                    onChange={(e) => setKeepMessages(e.target.checked)}
-                    className="rounded border-zinc-300 bg-zinc-100 text-green-500 focus:ring-green-500 dark:border-zinc-700 dark:bg-zinc-800"
-                  />
-                  <span className="text-sm">{t("chatWidget.keepMessages")}</span>
-                </label>
-              </div>
-
-              {hasBackground && (
-                <div>
-                  <label className="mb-1 block text-sm font-medium text-zinc-600 dark:text-zinc-400">
-                    {t("chatWidget.backgroundOpacity")}
-                  </label>
-                  <input
-                    type="range"
-                    min="0"
-                    max="1"
-                    step="0.1"
-                    value={backgroundOpacity}
-                    onChange={(e) => setBackgroundOpacity(e.target.value)}
-                    className="w-full h-2 bg-zinc-300 rounded-lg appearance-none cursor-pointer accent-green-500 dark:bg-zinc-700"
-                  />
-                  <div className="text-right text-xs text-zinc-500 mt-1">
-                    {backgroundOpacity}
                   </div>
+                  <div>
+                    <FieldLabel id={`${id}-indicator`} tip={t('chatWidget.platformIndicatorTip')}>
+                      {t('chatWidget.platformIndicator')}
+                    </FieldLabel>
+                    <Select
+                      labelledBy={`${id}-indicator`}
+                      disabled={settings.platforms !== 'both'}
+                      value={settings.platformDisplay}
+                      onChange={(value) => update('platformDisplay', value)}
+                      options={platformDisplayOptions}
+                    />
+                  </div>
+                  <div>
+                    <FieldLabel htmlFor={`${id}-twitch`} tip={t('chatWidget.channelTip')}>
+                      {t('chatWidget.twitchChannel')}
+                    </FieldLabel>
+                    <input
+                      id={`${id}-twitch`}
+                      type="text"
+                      disabled={settings.platforms === 'kick'}
+                      value={twitchChannel}
+                      onChange={(e) => setTwitchChannel(e.target.value)}
+                      placeholder={t('common.channelPlaceholder')}
+                      className={INPUT_CLASS}
+                    />
+                  </div>
+                  <div>
+                    <FieldLabel htmlFor={`${id}-kick`} tip={t('chatWidget.channelTip')}>
+                      {t('chatWidget.kickChannel')}
+                    </FieldLabel>
+                    <input
+                      id={`${id}-kick`}
+                      type="text"
+                      disabled={settings.platforms === 'twitch'}
+                      value={kickChannel}
+                      onChange={(e) => setKickChannel(e.target.value)}
+                      placeholder={t('common.channelPlaceholder')}
+                      className={INPUT_CLASS}
+                    />
+                  </div>
+                </div>
+              </SettingsGroup>
+
+              <SettingsGroup title={t('chatWidget.sectionAppearance')}>
+                <div className="grid grid-cols-2 gap-3 sm:grid-cols-[minmax(0,1.3fr)_minmax(0,1fr)_minmax(0,1fr)]">
+                  <div>
+                    <FieldLabel id={`${id}-font`}>{t('chatWidget.font')}</FieldLabel>
+                    <Select
+                      labelledBy={`${id}-font`}
+                      value={settings.font}
+                      onChange={(value) => update('font', value)}
+                      options={fontOptions}
+                    />
+                  </div>
+                  <div>
+                    <FieldLabel htmlFor={`${id}-font-size`}>{t('chatWidget.fontSize')}</FieldLabel>
+                    <NumberField
+                      id={`${id}-font-size`}
+                      value={settings.fontSize}
+                      onChange={(value) => update('fontSize', value)}
+                      min={8}
+                      max={72}
+                      fallback={Number(DEFAULT_SETTINGS.fontSize)}
+                    />
+                  </div>
+                  <div className="col-span-2 sm:col-span-1">
+                    <FieldLabel id={`${id}-orientation`} tip={t('chatWidget.orientationTip')}>
+                      {t('chatWidget.orientation')}
+                    </FieldLabel>
+                    <SegmentedControl
+                      labelledBy={`${id}-orientation`}
+                      value={settings.orientation}
+                      onChange={(value) => update('orientation', value)}
+                      options={orientationOptions}
+                    />
+                  </div>
+                </div>
+                <div>
+                  <FieldLabel id={`${id}-layout`}>{t('chatWidget.messageLayout')}</FieldLabel>
+                  <Select
+                    labelledBy={`${id}-layout`}
+                    value={settings.layout}
+                    onChange={(value) => update('layout', value)}
+                    options={layoutOptions}
+                  />
+                </div>
+                <div className="grid gap-x-6 gap-y-1 sm:grid-cols-2">
+                  <Switch
+                    label={t('chatWidget.darkBackground')}
+                    tip={t('chatWidget.darkBackgroundTip')}
+                    checked={settings.background}
+                    onChange={(value) => update('background', value)}
+                  />
+                  <div className="flex min-h-7 items-center gap-3">
+                    <input
+                      type="range"
+                      min="0"
+                      max="1"
+                      step="0.1"
+                      aria-label={t('chatWidget.backgroundOpacity')}
+                      title={t('chatWidget.backgroundOpacity')}
+                      disabled={!settings.background}
+                      value={settings.bgOpacity}
+                      onChange={(e) => update('bgOpacity', e.target.value)}
+                      className={RANGE_CLASS}
+                    />
+                    <span
+                      className={`w-9 shrink-0 text-right text-xs tabular-nums text-zinc-500 ${settings.background ? '' : 'opacity-40'}`}
+                    >
+                      {Math.round(Number(settings.bgOpacity) * 100)}%
+                    </span>
+                  </div>
+                  <Switch
+                    label={t('chatWidget.messageBackgroundBox')}
+                    tip={t('chatWidget.messageBackgroundHint')}
+                    checked={settings.itemBackground}
+                    onChange={(value) => update('itemBackground', value)}
+                  />
+                  <Switch
+                    label={t('chatWidget.platformAccent')}
+                    tip={t('chatWidget.platformAccentHint')}
+                    checked={settings.platformAccent}
+                    onChange={(value) => update('platformAccent', value)}
+                  />
+                  <Switch
+                    label={t('chatWidget.boldUsernames')}
+                    checked={settings.boldUsernames}
+                    onChange={(value) => update('boldUsernames', value)}
+                  />
+                  <Switch
+                    label={t('chatWidget.boldMessages')}
+                    checked={settings.boldMessages}
+                    onChange={(value) => update('boldMessages', value)}
+                  />
+                </div>
+              </SettingsGroup>
+
+              <SettingsGroup title={t('chatWidget.sectionMessages')}>
+                <div>
+                  <FieldLabel id={`${id}-animation`} tip={t('chatWidget.animationTip')}>
+                    {t('chatWidget.newMessageAnimation')}
+                  </FieldLabel>
+                  <Select
+                    labelledBy={`${id}-animation`}
+                    value={settings.animation}
+                    onChange={(value) => update('animation', value)}
+                    options={animationOptions}
+                  />
+                </div>
+                <div className="grid gap-x-6 gap-y-1 sm:grid-cols-2">
+                  <Switch
+                    label={t('chatWidget.sevenTvEmotes')}
+                    tip={t('chatWidget.sevenTvTip')}
+                    checked={settings.sevenTv}
+                    onChange={(value) => update('sevenTv', value)}
+                  />
+                  <Switch
+                    label={t('chatWidget.showBadges')}
+                    tip={t('chatWidget.badgesTip')}
+                    checked={settings.badges}
+                    onChange={(value) => update('badges', value)}
+                  />
+                  <Switch
+                    label={t('chatWidget.showMessageTime')}
+                    checked={settings.timestamp}
+                    onChange={(value) => update('timestamp', value)}
+                  />
+                  <Switch
+                    label={t('chatWidget.keepMessages')}
+                    tip={t('chatWidget.keepMessagesTip')}
+                    checked={settings.keep}
+                    onChange={(value) => update('keep', value)}
+                  />
+                </div>
+              </SettingsGroup>
+            </div>
+          </div>
+
+          <div className={`${PANEL_CLASS} flex h-[640px] flex-col gap-3 p-5 lg:h-auto lg:min-h-0`}>
+            <div className="flex items-center gap-1">
+              <h2 className="text-sm font-semibold text-zinc-700 dark:text-zinc-300">
+                {t('chatWidget.previewTitle')}
+              </h2>
+              <InfoTip text={t('chatWidget.previewHint')} />
+            </div>
+            <div className="relative min-h-0 flex-1 overflow-hidden rounded-lg border border-zinc-300 bg-zinc-950/80 shadow-inner dark:border-zinc-800">
+              {mounted ? (
+                <iframe
+                  src={previewUrl}
+                  className="pointer-events-none absolute inset-0 h-full w-full border-0"
+                  title={t('chatWidget.previewIframeTitle')}
+                />
+              ) : (
+                <div className="flex h-full items-center justify-center text-sm text-zinc-500">
+                  {t('common.previewNoChannel')}
                 </div>
               )}
-
-              <div>
-                <label className="flex items-center space-x-2 text-zinc-900 cursor-pointer dark:text-white">
-                  <input
-                    type="checkbox"
-                    checked={itemBackground}
-                    onChange={(e) => setItemBackground(e.target.checked)}
-                    className="rounded border-zinc-300 bg-zinc-100 text-green-500 focus:ring-green-500 dark:border-zinc-700 dark:bg-zinc-800"
-                  />
-                  <span className="text-sm">{t("chatWidget.messageBackgroundBox")}</span>
-                </label>
-                <p className="mt-1 text-xs text-zinc-500">
-                  {t("chatWidget.messageBackgroundHint")}
-                </p>
-              </div>
-
-              <div>
-                <label className="flex items-center space-x-2 text-zinc-900 cursor-pointer dark:text-white">
-                  <input
-                    type="checkbox"
-                    checked={platformAccent}
-                    onChange={(e) => setPlatformAccent(e.target.checked)}
-                    className="rounded border-zinc-300 bg-zinc-100 text-green-500 focus:ring-green-500 dark:border-zinc-700 dark:bg-zinc-800"
-                  />
-                  <span className="text-sm">{t("chatWidget.platformAccent")}</span>
-                </label>
-                <p className="mt-1 text-xs text-zinc-500">
-                  {t("chatWidget.platformAccentHint")}
-                </p>
-              </div>
-
-              <div>
-                <label className="flex items-center space-x-2 text-zinc-900 cursor-pointer dark:text-white">
-                  <input
-                    type="checkbox"
-                    checked={boldUsernames}
-                    onChange={(e) => setBoldUsernames(e.target.checked)}
-                    className="rounded border-zinc-300 bg-zinc-100 text-green-500 focus:ring-green-500 dark:border-zinc-700 dark:bg-zinc-800"
-                  />
-                  <span className="text-sm">{t("chatWidget.boldUsernames")}</span>
-                </label>
-              </div>
-
-              <div>
-                <label className="flex items-center space-x-2 text-zinc-900 cursor-pointer dark:text-white">
-                  <input
-                    type="checkbox"
-                    checked={boldMessages}
-                    onChange={(e) => setBoldMessages(e.target.checked)}
-                    className="rounded border-zinc-300 bg-zinc-100 text-green-500 focus:ring-green-500 dark:border-zinc-700 dark:bg-zinc-800"
-                  />
-                  <span className="text-sm">{t("chatWidget.boldMessages")}</span>
-                </label>
-              </div>
-
-              <div className="pt-4 mt-6 border-t border-zinc-200 lg:hidden dark:border-zinc-800">
-                <label className="mb-1 block text-sm font-medium text-zinc-600 dark:text-zinc-400">
-                  {t("common.widgetUrl")}
-                </label>
-                <div className="flex">
-                  <input
-                    type="text"
-                    readOnly
-                    value={widgetUrl}
-                    className="w-full rounded-l-md border border-zinc-300 bg-zinc-100 px-3 py-2 text-zinc-600 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
-                  />
-                  <button
-                    onClick={handleCopy}
-                    disabled={!isFormValid}
-                    className="rounded-r-md bg-green-600 px-4 py-2 font-medium text-white hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
-                    {copied ? t("common.copied") : t("common.copy")}
-                  </button>
-                </div>
-              </div>
             </div>
-          </div>
-
-          {/* Right: Live Preview Panel & Guides/FAQ */}
-          <div className="w-full max-w-md lg:max-w-2xl lg:shrink-0 flex flex-col gap-4 lg:sticky lg:top-6">
-            <div className="rounded-xl bg-white p-6 md:p-8 shadow-xl border border-zinc-200 flex flex-col h-[700px] dark:bg-zinc-900 dark:border-zinc-800">
-              <h2 className="mb-4 text-xl font-semibold text-center text-zinc-700 dark:text-zinc-300">
-                {t("chatWidget.previewTitle")}
-              </h2>
-              <div className="flex-1 w-full bg-zinc-950/80 rounded-lg overflow-hidden border border-zinc-300 relative shadow-inner flex items-center justify-center dark:border-zinc-800">
-                {mounted ? (
-                  <iframe
-                    src={previewUrl}
-                    className="absolute inset-0 w-full h-full border-0 pointer-events-none"
-                    title={t("chatWidget.previewIframeTitle")}
-                  />
-                ) : (
-                  <div className="text-center text-zinc-500">
-                    <p>{t("common.previewNoChannel")}</p>
-                  </div>
-                )}
+            <div className="flex items-center gap-3">
+              <div className="flex shrink-0 items-center gap-1">
+                <label
+                  htmlFor={`${id}-speed`}
+                  className="text-xs font-medium text-zinc-600 dark:text-zinc-400"
+                >
+                  {t('chatWidget.previewSpeed')}
+                </label>
+                <InfoTip text={t('chatWidget.previewSpeedHint')} />
               </div>
-              <p className="mt-2 text-center text-xs text-zinc-500">
-                {t("chatWidget.previewHint")}
-              </p>
-
-              <div className="mt-3">
-                <div className="mb-1 flex items-center justify-between">
-                  <label
-                    htmlFor="preview-chat-speed"
-                    className="text-sm font-medium text-zinc-600 dark:text-zinc-400">
-                    {t("chatWidget.previewSpeed")}
-                  </label>
-                  <span className="text-xs text-zinc-500">
-                    {t("chatWidget.previewSpeedValue", {
-                      rate: PREVIEW_RATES[previewRateIndex],
-                    })}
-                  </span>
-                </div>
+              <input
+                id={`${id}-speed`}
+                type="range"
+                min="0"
+                max={PREVIEW_RATES.length - 1}
+                step="1"
+                value={previewRateIndex}
+                onChange={(e) => setPreviewRateIndex(Number(e.target.value))}
+                className={RANGE_CLASS}
+              />
+              <span className="w-20 shrink-0 text-right text-xs tabular-nums text-zinc-500">
+                {t('chatWidget.previewSpeedValue', { rate: PREVIEW_RATES[previewRateIndex] })}
+              </span>
+            </div>
+            <div className="border-t border-zinc-200 pt-3 dark:border-zinc-800">
+              <FieldLabel htmlFor={`${id}-url`}>{t('common.widgetUrl')}</FieldLabel>
+              <div className="flex">
                 <input
-                  id="preview-chat-speed"
-                  type="range"
-                  min="0"
-                  max={PREVIEW_RATES.length - 1}
-                  step="1"
-                  value={previewRateIndex}
-                  onChange={(e) => setPreviewRateIndex(Number(e.target.value))}
-                  className="w-full h-2 bg-zinc-300 rounded-lg appearance-none cursor-pointer accent-green-500 dark:bg-zinc-700"
+                  id={`${id}-url`}
+                  type="text"
+                  readOnly
+                  value={widgetUrl}
+                  onFocus={(e) => e.currentTarget.select()}
+                  className="h-9 w-full min-w-0 rounded-l-md border border-zinc-300 bg-zinc-100 px-3 text-sm text-zinc-600 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
                 />
-                <p className="mt-1 text-xs text-zinc-500">
-                  {t("chatWidget.previewSpeedHint")}
-                </p>
+                <button
+                  type="button"
+                  onClick={handleCopy}
+                  disabled={!widgetUrl}
+                  className="h-9 shrink-0 rounded-r-md bg-green-600 px-4 text-sm font-medium text-white transition-colors hover:bg-green-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {copied ? t('common.copied') : t('common.copy')}
+                </button>
               </div>
-
-              <div className="mt-4 hidden lg:block">
-                <label className="mb-1 block text-sm font-medium text-zinc-600 dark:text-zinc-400">
-                  {t("common.widgetUrl")}
-                </label>
-                <div className="flex">
-                  <input
-                    type="text"
-                    readOnly
-                    value={widgetUrl}
-                    className="w-full rounded-l-md border border-zinc-300 bg-zinc-100 px-3 py-2 text-zinc-600 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
-                  />
-                  <button
-                    onClick={handleCopy}
-                    disabled={!isFormValid}
-                    className="rounded-r-md bg-green-600 px-4 py-2 font-medium text-white hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
-                    {copied ? t("common.copied") : t("common.copy")}
-                  </button>
-                </div>
-                <p className="mt-2 text-xs text-zinc-500">
-                  {t("common.browserSourceHint")}
-                  {t("chatWidget.browserSourceHintSize")}
-                </p>
-              </div>
-            </div>
-
-            {/* Quick OBS Guide & FAQ (Placed under preview) */}
-            <div className="space-y-4">
-              <div className="rounded-xl border border-zinc-200 bg-zinc-100/60 p-5 dark:border-zinc-800 dark:bg-zinc-900/50">
-                <h3 className="text-sm font-semibold text-zinc-900 mb-2 dark:text-white">{t("chatWidget.guideTitle")}</h3>
-                <p className="text-xs text-zinc-600 leading-relaxed dark:text-zinc-400">
-                  {t("chatWidget.guideStep1")}<br />
-                  {t("chatWidget.guideStep2")}<br />
-                  {t("chatWidget.guideStep3")}
-                </p>
-              </div>
-
-              <div className="space-y-3">
-                <details className="group rounded-lg border border-zinc-200/80 bg-zinc-100/60 p-4 transition-colors open:bg-zinc-100 dark:border-zinc-800/80 dark:bg-zinc-900/50 dark:open:bg-zinc-900">
-                  <summary className="flex cursor-pointer list-none items-center justify-between text-sm font-medium text-zinc-700 group-hover:text-zinc-900 dark:text-zinc-200 dark:group-hover:text-white">
-                    <span>{t("chatWidget.faq1Q")}</span>
-                    <span className="transition-transform group-open:rotate-180 text-zinc-500 text-xs">▼</span>
-                  </summary>
-                  <p className="mt-2 text-xs text-zinc-600 leading-relaxed dark:text-zinc-400">
-                    {t("chatWidget.faq1A")}
-                  </p>
-                </details>
-
-                <details className="group rounded-lg border border-zinc-200/80 bg-zinc-100/60 p-4 transition-colors open:bg-zinc-100 dark:border-zinc-800/80 dark:bg-zinc-900/50 dark:open:bg-zinc-900">
-                  <summary className="flex cursor-pointer list-none items-center justify-between text-sm font-medium text-zinc-700 group-hover:text-zinc-900 dark:text-zinc-200 dark:group-hover:text-white">
-                    <span>{t("chatWidget.faq2Q")}</span>
-                    <span className="transition-transform group-open:rotate-180 text-zinc-500 text-xs">▼</span>
-                  </summary>
-                  <p className="mt-2 text-xs text-zinc-600 leading-relaxed dark:text-zinc-400">
-                    {t("chatWidget.faq2A")}
-                  </p>
-                </details>
-              </div>
+              <p className="mt-2 text-xs leading-relaxed text-zinc-500">
+                {t('common.browserSourceHint')}
+                {t('chatWidget.browserSourceHintSize')}
+              </p>
             </div>
           </div>
+        </div>
+      </div>
+
+      <div className="mx-auto grid max-w-6xl gap-4 px-4 pt-4 pb-12 lg:grid-cols-2">
+        <div className="space-y-4">
+          <p className="text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">
+            {t('chatWidget.intro')}
+          </p>
+          <YoutubeTutorial />
+          <div className="rounded-xl border border-zinc-200 bg-zinc-100/60 p-5 dark:border-zinc-800 dark:bg-zinc-900/50">
+            <h3 className="mb-2 text-sm font-semibold text-zinc-900 dark:text-white">
+              {t('chatWidget.guideTitle')}
+            </h3>
+            <p className="text-xs leading-relaxed text-zinc-600 dark:text-zinc-400">
+              {t('chatWidget.guideStep1')}
+              <br />
+              {t('chatWidget.guideStep2')}
+              <br />
+              {t('chatWidget.guideStep3')}
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          {(
+            [
+              ['chatWidget.faq1Q', 'chatWidget.faq1A'],
+              ['chatWidget.faq2Q', 'chatWidget.faq2A'],
+            ] as const
+          ).map(([question, answer]) => (
+            <details
+              key={question}
+              className="group rounded-lg border border-zinc-200/80 bg-zinc-100/60 p-4 transition-colors open:bg-zinc-100 dark:border-zinc-800/80 dark:bg-zinc-900/50 dark:open:bg-zinc-900"
+            >
+              <summary className="flex cursor-pointer list-none items-center justify-between gap-3 text-sm font-medium text-zinc-700 group-hover:text-zinc-900 dark:text-zinc-200 dark:group-hover:text-white">
+                <span>{t(question)}</span>
+                <span className="text-xs text-zinc-500 transition-transform group-open:rotate-180">
+                  ▼
+                </span>
+              </summary>
+              <p className="mt-2 text-xs leading-relaxed text-zinc-600 dark:text-zinc-400">
+                {t(answer)}
+              </p>
+            </details>
+          ))}
         </div>
       </div>
     </div>

--- a/apps/extensions/src/routes/setup/chat-widget.tsx
+++ b/apps/extensions/src/routes/setup/chat-widget.tsx
@@ -136,7 +136,7 @@ function ChatWidgetSetup() {
     "inline" | "stacked" | "card" | "compact"
   >("inline");
   const [animation, setAnimation] = useState<
-    "slide" | "pop" | "bounce" | "stagger" | "fade" | "none"
+    "slide" | "pop" | "bounce" | "stagger" | "fade" | "typing" | "none"
   >("slide");
   const [copied, setCopied] = useState(false);
   const [mounted, setMounted] = useState(false);
@@ -443,6 +443,7 @@ function ChatWidgetSetup() {
                             | "bounce"
                             | "stagger"
                             | "fade"
+                            | "typing"
                             | "none",
                         )
                       }
@@ -454,6 +455,7 @@ function ChatWidgetSetup() {
                         {t("chatWidget.animStagger")}
                       </option>
                       <option value="fade">{t("chatWidget.animFade")}</option>
+                      <option value="typing">{t("chatWidget.animTyping")}</option>
                       <option value="none">{t("chatWidget.animNone")}</option>
                     </select>
                   </div>

--- a/apps/extensions/src/routes/setup/chat-widget.tsx
+++ b/apps/extensions/src/routes/setup/chat-widget.tsx
@@ -105,6 +105,9 @@ export const Route = createFileRoute("/setup/chat-widget")({
   component: ChatWidgetSetup,
 });
 
+// Messages per second for the mock preview only; index 0 keeps the widget's default mock pace.
+const PREVIEW_RATES = [0.3, 0.5, 1, 2, 3, 5, 10, 15, 20];
+
 function ChatWidgetSetup() {
   const { locale, t } = useI18n();
   const [twitchChannel, setTwitchChannel] = useState("");
@@ -136,8 +139,9 @@ function ChatWidgetSetup() {
     "inline" | "stacked" | "card" | "compact"
   >("inline");
   const [animation, setAnimation] = useState<
-    "slide" | "pop" | "bounce" | "stagger" | "fade" | "typing" | "none"
+    "slide" | "smooth" | "pop" | "bounce" | "stagger" | "fade" | "typing" | "none"
   >("slide");
+  const [previewRateIndex, setPreviewRateIndex] = useState(0);
   const [copied, setCopied] = useState(false);
   const [mounted, setMounted] = useState(false);
 
@@ -228,6 +232,8 @@ function ChatWidgetSetup() {
     if (layout !== "inline") params.append("layout", layout);
     if (animation !== "slide") params.append("animation", animation);
     params.append("mock", "true");
+    if (previewRateIndex > 0)
+      params.append("mockRate", String(PREVIEW_RATES[previewRateIndex]));
     params.append("lang", locale);
     return `${window.location.origin}/widgets/chat-widget?${params.toString()}`;
   }, [
@@ -250,6 +256,7 @@ function ChatWidgetSetup() {
     font,
     layout,
     animation,
+    previewRateIndex,
     locale,
   ]);
 
@@ -439,6 +446,7 @@ function ChatWidgetSetup() {
                         setAnimation(
                           e.target.value as
                             | "slide"
+                            | "smooth"
                             | "pop"
                             | "bounce"
                             | "stagger"
@@ -449,6 +457,7 @@ function ChatWidgetSetup() {
                       }
                       className="w-full rounded-md border border-zinc-300 bg-zinc-100 px-3 py-2.5 text-zinc-900 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500">
                       <option value="slide">{t("chatWidget.animSlide")}</option>
+                      <option value="smooth">{t("chatWidget.animSmoothSlide")}</option>
                       <option value="pop">{t("chatWidget.animPop")}</option>
                       <option value="bounce">{t("chatWidget.animBounce")}</option>
                       <option value="stagger">
@@ -671,6 +680,34 @@ function ChatWidgetSetup() {
               <p className="mt-2 text-center text-xs text-zinc-500">
                 {t("chatWidget.previewHint")}
               </p>
+
+              <div className="mt-3">
+                <div className="mb-1 flex items-center justify-between">
+                  <label
+                    htmlFor="preview-chat-speed"
+                    className="text-sm font-medium text-zinc-600 dark:text-zinc-400">
+                    {t("chatWidget.previewSpeed")}
+                  </label>
+                  <span className="text-xs text-zinc-500">
+                    {t("chatWidget.previewSpeedValue", {
+                      rate: PREVIEW_RATES[previewRateIndex],
+                    })}
+                  </span>
+                </div>
+                <input
+                  id="preview-chat-speed"
+                  type="range"
+                  min="0"
+                  max={PREVIEW_RATES.length - 1}
+                  step="1"
+                  value={previewRateIndex}
+                  onChange={(e) => setPreviewRateIndex(Number(e.target.value))}
+                  className="w-full h-2 bg-zinc-300 rounded-lg appearance-none cursor-pointer accent-green-500 dark:bg-zinc-700"
+                />
+                <p className="mt-1 text-xs text-zinc-500">
+                  {t("chatWidget.previewSpeedHint")}
+                </p>
+              </div>
 
               <div className="mt-4 hidden lg:block">
                 <label className="mb-1 block text-sm font-medium text-zinc-600 dark:text-zinc-400">

--- a/apps/extensions/src/routes/widgets/chat-widget.tsx
+++ b/apps/extensions/src/routes/widgets/chat-widget.tsx
@@ -168,7 +168,7 @@ const searchSchema = z.object({
   bgOpacity: z.coerce.number().min(0).max(1).optional().default(0.5),
   platformAccent: z.coerce.boolean().optional(),
   orientation: z.enum(['vertical', 'horizontal']).optional().default('vertical'),
-  platformDisplay: z.enum(['name', 'icon']).optional().default('icon'),
+  platformDisplay: z.enum(['name', 'icon', 'none']).optional().default('icon'),
   timestamp: z.coerce.boolean().optional(),
   keep: z.coerce.boolean().optional(),
   font: z
@@ -411,12 +411,7 @@ function RouteComponent() {
 
   const isMock = Boolean(search.mock || (!search.twitch && !kick));
 
-  const showPlatformIndicator = Boolean(
-    (search.twitch && search.kick) ||
-      isMock ||
-      search.platformDisplay === 'name' ||
-      search.platformDisplay === 'icon'
-  );
+  const showPlatformIndicator = search.platformDisplay !== 'none';
 
   const sevenTvEmoteMap = use7tvEmotes(search.sevenTv ? search.twitch : null);
 
@@ -743,7 +738,7 @@ type MessageRowProps = {
   orientation: 'vertical' | 'horizontal';
   showTimestamp: boolean;
   showPlatformIndicator: boolean;
-  platformDisplay: 'name' | 'icon';
+  platformDisplay: 'name' | 'icon' | 'none';
   twitchBadgeMap: Map<string, string> | null | undefined;
   kickSubBadges: {
     months?: number;

--- a/apps/extensions/src/routes/widgets/chat-widget.tsx
+++ b/apps/extensions/src/routes/widgets/chat-widget.tsx
@@ -12,6 +12,12 @@ import { getKickChannelInfo } from '#/lib/kick';
 import { getAccessibleColor } from '#/features/widgets/chat-widget/color-utils';
 
 const TTL_MS = 30_000;
+// Must cover the 1s `now` tick, otherwise a row can expire without ever getting its fade-out class.
+const EXIT_MS = 1_000;
+const SHIFT_TRANSITION = 'transform 400ms cubic-bezier(0.22, 1, 0.36, 1)';
+
+const getReceivedAtMs = (msg: ChatMessagesType) =>
+  msg.receivedAt?.getTime() ?? msg.timestamp.getTime();
 
 type TwitchEmoteRange = { id: string; start: number; end: number };
 
@@ -159,7 +165,7 @@ const searchSchema = z.object({
   layout: z.enum(['inline', 'stacked', 'card', 'compact']).optional().default('inline'),
   mock: z.coerce.boolean().optional(),
   animation: z
-    .enum(['slide', 'pop', 'bounce', 'stagger', 'fade', 'none'])
+    .enum(['slide', 'pop', 'bounce', 'stagger', 'fade', 'typing', 'none'])
     .optional()
     .default('slide'),
 });
@@ -225,6 +231,7 @@ const ANIMATION_CLASSES: Record<
   bounce: () => 'animate-chat-bounce-in',
   stagger: () => 'animate-chat-stagger-meta',
   fade: () => 'animate-chat-fade-in',
+  typing: () => 'animate-chat-fade-in',
   none: () => '',
 };
 
@@ -234,8 +241,65 @@ const ANIMATION_MESSAGE_CLASSES: Record<AnimationChoice, string> = {
   bounce: '',
   stagger: 'animate-chat-stagger-message',
   fade: '',
+  typing: '',
   none: '',
 };
+
+const TYPING_MS_PER_CHAR = 35;
+// Long messages type faster so no message takes longer than this to finish.
+const TYPING_MAX_MS = 1_500;
+
+// Grapheme clusters, so emoji like 🏴‍☠️ are never shown half-typed.
+const splitGraphemes = (text: string): string[] =>
+  typeof Intl.Segmenter === 'function'
+    ? Array.from(
+        new Intl.Segmenter(undefined, { granularity: 'grapheme' }).segment(text),
+        (s) => s.segment,
+      )
+    : Array.from(text);
+
+function TypedContent({ nodes }: { nodes: React.ReactNode[] }) {
+  const units = React.useMemo(
+    () =>
+      nodes.flatMap((node) => {
+        if (node == null || typeof node === 'boolean' || node === '') return [];
+        return typeof node === 'string' ? splitGraphemes(node) : [node];
+      }),
+    [nodes],
+  );
+  const [count, setCount] = React.useState(0);
+  // Kept across effect restarts so a late emote-map load doesn't retype the message from scratch.
+  const startRef = React.useRef<number | null>(null);
+
+  React.useEffect(() => {
+    startRef.current ??= performance.now();
+    const start = startRef.current;
+    const msPerUnit = Math.min(TYPING_MS_PER_CHAR, TYPING_MAX_MS / Math.max(units.length, 1));
+    const id = window.setInterval(() => {
+      const next = Math.min(units.length, Math.ceil((performance.now() - start) / msPerUnit));
+      setCount(next);
+      if (next >= units.length) window.clearInterval(id);
+    }, 30);
+    return () => window.clearInterval(id);
+  }, [units.length]);
+
+  if (count >= units.length) return <>{nodes}</>;
+
+  const caretUnit = count > 0 ? units[count - 1] : null;
+  // The untyped rest stays in the layout (just invisible) so the row has its final size from the
+  // first frame; otherwise every wrapped line would push older rows up again.
+  return (
+    <>
+      {units.slice(0, Math.max(count - 1, 0))}
+      {typeof caretUnit === 'string' ? (
+        <span className="chat-typing-caret">{caretUnit}</span>
+      ) : (
+        caretUnit
+      )}
+      <span style={{ visibility: 'hidden' }}>{units.slice(count)}</span>
+    </>
+  );
+}
 
 const PLATFORM_COLORS: Record<'twitch' | 'kick', string> = {
   twitch: '#9146FF',
@@ -507,7 +571,8 @@ function RouteComponent() {
   }, [isMock]);
 
   const [now, setNow] = React.useState(() => Date.now());
-  const containerRef = React.useRef<HTMLDivElement>(null);
+  const listRef = React.useRef<HTMLDivElement>(null);
+  const lastIdRef = React.useRef<string | null>(null);
 
   React.useEffect(() => {
     if (typeof document === 'undefined') return;
@@ -550,10 +615,8 @@ function RouteComponent() {
 
   const visibleMessages = search.keep
     ? messages
-    : messages.filter((msg) => {
-      const receivedAtMs = msg.receivedAt?.getTime() ?? msg.timestamp.getTime();
-      return now - receivedAtMs < TTL_MS;
-    });
+    : messages.filter((msg) => now - getReceivedAtMs(msg) < TTL_MS);
+  const fadeOut = !search.keep && search.animation !== 'none';
 
   const hasVisibleMessages = visibleMessages.length > 0;
 
@@ -572,54 +635,85 @@ function RouteComponent() {
     };
   }, [hasVisibleMessages, search.keep]);
 
-  React.useEffect(() => {
-    if (!containerRef.current) return;
+  // The list is anchored to the bottom (right when horizontal), so appending a row makes every
+  // older row jump by its size. Offset the list back by that jump, then transition it to rest.
+  React.useLayoutEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const horizontal = search.orientation === 'horizontal';
+    // Measured from the new rows themselves rather than a stored position, so a late image load
+    // that resized an older row is not replayed as a shift.
+    const endOf = (el: HTMLElement) =>
+      horizontal ? el.offsetLeft + el.offsetWidth : el.offsetTop + el.offsetHeight;
 
-    if (search.orientation === 'horizontal') {
-      containerRef.current.scrollLeft = containerRef.current.scrollWidth;
-    } else {
-      containerRef.current.scrollTop = containerRef.current.scrollHeight;
-    }
-  }, [visibleMessages, search.orientation]);
+    const prevId = lastIdRef.current;
+    const last = list.lastElementChild as HTMLElement | null;
+    lastIdRef.current = last?.dataset.msgId ?? null;
+    if (!prevId || !last || prevId === lastIdRef.current || search.animation === 'none') return;
 
+    const prevEl = list.querySelector<HTMLElement>(`[data-msg-id="${CSS.escape(prevId)}"]`);
+    if (!prevEl) return;
+    const shift = endOf(last) - endOf(prevEl);
+    if (shift <= 0) return;
+
+    // Carry over what is left of a shift that is still running so back-to-back messages don't jump.
+    const running = new DOMMatrixReadOnly(getComputedStyle(list).transform);
+    const start = shift + (horizontal ? running.m41 : running.m42);
+    list.style.transition = 'none';
+    list.style.transform = horizontal ? `translateX(${start}px)` : `translateY(${start}px)`;
+    void list.offsetWidth;
+    list.style.transition = SHIFT_TRANSITION;
+    list.style.transform = '';
+  });
+
+  const horizontal = search.orientation === 'horizontal';
+
+  // Rows overflow toward the start edge, which is never scrollable, so clip instead of scroll:
+  // a scrollable box would flash a scrollbar while the list is offset during the shift.
   return (
     <div
-      ref={containerRef}
-      className={`flex ${search.orientation === 'horizontal' ? 'flex-row justify-end items-center overflow-hidden min-w-full h-screen p-2 space-x-3' : 'flex-col justify-end h-screen w-full overflow-y-auto overflow-x-hidden p-2.5 space-y-2'} text-white rounded-md`}
+      className={`flex ${horizontal ? 'flex-row justify-end items-center min-w-full h-screen p-2' : 'flex-col justify-end h-screen w-full p-2.5'} overflow-clip text-white rounded-md`}
       style={{
         fontSize: `${search.fontSize}px`,
         fontFamily: FONT_STACKS[search.font],
         backgroundColor: search.background ? `rgba(0, 0, 0, ${search.bgOpacity})` : 'transparent',
       }}
     >
-      {visibleMessages.map((msg) => (
-        <MessageRow
-          key={msg.id}
-          msg={msg}
-          layout={search.layout}
-          animation={search.animation}
-          orientation={search.orientation}
-          showTimestamp={Boolean(search.timestamp)}
-          showPlatformIndicator={showPlatformIndicator}
-          platformDisplay={search.platformDisplay}
-          twitchBadgeMap={twitchBadgeMap}
-          kickSubBadges={kickSubBadges}
-          sevenTvEmoteMap={sevenTvEmoteMap}
-          showBadges={Boolean(search.badges)}
-          hasBackground={Boolean(search.background)}
-          itemBackground={Boolean(search.itemBackground)}
-          bgOpacity={search.bgOpacity}
-          platformAccent={Boolean(search.platformAccent)}
-          boldUsernames={Boolean(search.boldUsernames)}
-          boldMessages={Boolean(search.boldMessages)}
-        />
-      ))}
+      <div
+        ref={listRef}
+        className={`flex ${horizontal ? 'flex-row items-center space-x-3' : 'flex-col space-y-2'}`}
+      >
+        {visibleMessages.map((msg) => (
+          <MessageRow
+            key={msg.id}
+            msg={msg}
+            exiting={fadeOut && now - getReceivedAtMs(msg) >= TTL_MS - EXIT_MS}
+            layout={search.layout}
+            animation={search.animation}
+            orientation={search.orientation}
+            showTimestamp={Boolean(search.timestamp)}
+            showPlatformIndicator={showPlatformIndicator}
+            platformDisplay={search.platformDisplay}
+            twitchBadgeMap={twitchBadgeMap}
+            kickSubBadges={kickSubBadges}
+            sevenTvEmoteMap={sevenTvEmoteMap}
+            showBadges={Boolean(search.badges)}
+            hasBackground={Boolean(search.background)}
+            itemBackground={Boolean(search.itemBackground)}
+            bgOpacity={search.bgOpacity}
+            platformAccent={Boolean(search.platformAccent)}
+            boldUsernames={Boolean(search.boldUsernames)}
+            boldMessages={Boolean(search.boldMessages)}
+          />
+        ))}
+      </div>
     </div>
   );
 }
 
 type MessageRowProps = {
   msg: ChatMessagesType;
+  exiting: boolean;
   layout: LayoutChoice;
   animation: AnimationChoice;
   orientation: 'vertical' | 'horizontal';
@@ -643,6 +737,7 @@ type MessageRowProps = {
 
 const MessageRow = React.memo(function MessageRow({
   msg,
+  exiting,
   layout,
   animation,
   orientation,
@@ -661,7 +756,7 @@ const MessageRow = React.memo(function MessageRow({
   boldMessages,
 }: MessageRowProps) {
   const classes = LAYOUT_CLASSES[layout];
-  const animClass = ANIMATION_CLASSES[animation](orientation);
+  const animClass = exiting ? 'animate-chat-fade-out' : ANIMATION_CLASSES[animation](orientation);
   const messageAnimClass = ANIMATION_MESSAGE_CLASSES[animation];
   const compactSize = layout === 'compact' ? '0.875em' : undefined;
   const isInlineOrCompact = layout === 'inline' || layout === 'compact';
@@ -766,12 +861,13 @@ const MessageRow = React.memo(function MessageRow({
   const messageNode = (
     <span className={`${classes.message} ${messageAnimClass}`} style={messageStyle}>
       {layout === 'inline' || layout === 'compact' ? ' ' : null}
-      {parsedContent}
+      {animation === 'typing' ? <TypedContent nodes={parsedContent} /> : parsedContent}
     </span>
   );
 
   return (
     <div
+      data-msg-id={msg.id}
       className={`${classes.wrapper} ${itemBgClass} ${animClass} transform-gpu ${orientation === 'horizontal' ? 'flex-shrink-0' : ''}`}
       style={wrapperStyle}
     >

--- a/apps/extensions/src/routes/widgets/chat-widget.tsx
+++ b/apps/extensions/src/routes/widgets/chat-widget.tsx
@@ -14,10 +14,23 @@ import { getAccessibleColor } from '#/features/widgets/chat-widget/color-utils';
 const TTL_MS = 30_000;
 // Must cover the 1s `now` tick, otherwise a row can expire without ever getting its fade-out class.
 const EXIT_MS = 1_000;
-const SHIFT_TRANSITION = 'transform 400ms cubic-bezier(0.22, 1, 0.36, 1)';
+const SHIFT_MS = 400;
+// Busy chat speeds animations up so each one finishes before the next message lands: full speed
+// when messages are SPEED_BASE_GAP_MS or more apart, scaled down with the gap, never below MIN_SPEED.
+const SPEED_BASE_GAP_MS = 500;
+const MIN_SPEED = 0.35;
 
 const getReceivedAtMs = (msg: ChatMessagesType) =>
   msg.receivedAt?.getTime() ?? msg.timestamp.getTime();
+
+const getAnimationSpeeds = (messages: ChatMessagesType[]) => {
+  const speeds = new Map<string, number>();
+  messages.forEach((msg, i) => {
+    const gap = i > 0 ? getReceivedAtMs(msg) - getReceivedAtMs(messages[i - 1]) : Infinity;
+    speeds.set(msg.id, Math.min(1, Math.max(MIN_SPEED, gap / SPEED_BASE_GAP_MS)));
+  });
+  return speeds;
+};
 
 type TwitchEmoteRange = { id: string; start: number; end: number };
 
@@ -164,8 +177,9 @@ const searchSchema = z.object({
     .default('inter'),
   layout: z.enum(['inline', 'stacked', 'card', 'compact']).optional().default('inline'),
   mock: z.coerce.boolean().optional(),
+  mockRate: z.coerce.number().min(0.1).max(50).optional(),
   animation: z
-    .enum(['slide', 'pop', 'bounce', 'stagger', 'fade', 'typing', 'none'])
+    .enum(['slide', 'smooth', 'pop', 'bounce', 'stagger', 'fade', 'typing', 'none'])
     .optional()
     .default('slide'),
 });
@@ -227,6 +241,7 @@ const ANIMATION_CLASSES: Record<
   (orientation: 'vertical' | 'horizontal') => string
 > = {
   slide: () => 'animate-chat-slide-in',
+  smooth: () => 'animate-chat-smooth-slide-in',
   pop: () => 'animate-chat-pop-in',
   bounce: () => 'animate-chat-bounce-in',
   stagger: () => 'animate-chat-stagger-meta',
@@ -237,6 +252,7 @@ const ANIMATION_CLASSES: Record<
 
 const ANIMATION_MESSAGE_CLASSES: Record<AnimationChoice, string> = {
   slide: '',
+  smooth: '',
   pop: '',
   bounce: '',
   stagger: 'animate-chat-stagger-message',
@@ -258,7 +274,7 @@ const splitGraphemes = (text: string): string[] =>
       )
     : Array.from(text);
 
-function TypedContent({ nodes }: { nodes: React.ReactNode[] }) {
+function TypedContent({ nodes, speed }: { nodes: React.ReactNode[]; speed: number }) {
   const units = React.useMemo(
     () =>
       nodes.flatMap((node) => {
@@ -274,14 +290,15 @@ function TypedContent({ nodes }: { nodes: React.ReactNode[] }) {
   React.useEffect(() => {
     startRef.current ??= performance.now();
     const start = startRef.current;
-    const msPerUnit = Math.min(TYPING_MS_PER_CHAR, TYPING_MAX_MS / Math.max(units.length, 1));
+    const msPerUnit =
+      speed * Math.min(TYPING_MS_PER_CHAR, TYPING_MAX_MS / Math.max(units.length, 1));
     const id = window.setInterval(() => {
       const next = Math.min(units.length, Math.ceil((performance.now() - start) / msPerUnit));
       setCount(next);
       if (next >= units.length) window.clearInterval(id);
     }, 30);
     return () => window.clearInterval(id);
-  }, [units.length]);
+  }, [units.length, speed]);
 
   if (count >= units.length) return <>{nodes}</>;
 
@@ -559,7 +576,7 @@ function RouteComponent() {
     };
 
     const firstTimer = setTimeout(insertNextMock, 400);
-    const interval = setInterval(insertNextMock, 3000);
+    const interval = setInterval(insertNextMock, search.mockRate ? 1000 / search.mockRate : 3000);
 
     return () => {
       clearTimeout(firstTimer);
@@ -568,7 +585,7 @@ function RouteComponent() {
         chatMessagesCollection.delete(id);
       }
     };
-  }, [isMock]);
+  }, [isMock, search.mockRate]);
 
   const [now, setNow] = React.useState(() => Date.now());
   const listRef = React.useRef<HTMLDivElement>(null);
@@ -616,7 +633,11 @@ function RouteComponent() {
   const visibleMessages = search.keep
     ? messages
     : messages.filter((msg) => now - getReceivedAtMs(msg) < TTL_MS);
-  const fadeOut = !search.keep && search.animation !== 'none';
+  // `slide` is the original default and must look exactly as it always did, so the shift and
+  // fade-out only come with the other animations.
+  const animatesLayout = search.animation !== 'none' && search.animation !== 'slide';
+  const fadeOut = !search.keep && animatesLayout;
+  const speeds = React.useMemo(() => getAnimationSpeeds(messages), [messages]);
 
   const hasVisibleMessages = visibleMessages.length > 0;
 
@@ -649,7 +670,7 @@ function RouteComponent() {
     const prevId = lastIdRef.current;
     const last = list.lastElementChild as HTMLElement | null;
     lastIdRef.current = last?.dataset.msgId ?? null;
-    if (!prevId || !last || prevId === lastIdRef.current || search.animation === 'none') return;
+    if (!prevId || !last || prevId === lastIdRef.current || !animatesLayout) return;
 
     const prevEl = list.querySelector<HTMLElement>(`[data-msg-id="${CSS.escape(prevId)}"]`);
     if (!prevEl) return;
@@ -662,7 +683,8 @@ function RouteComponent() {
     list.style.transition = 'none';
     list.style.transform = horizontal ? `translateX(${start}px)` : `translateY(${start}px)`;
     void list.offsetWidth;
-    list.style.transition = SHIFT_TRANSITION;
+    const shiftMs = Math.round(SHIFT_MS * (speeds.get(lastIdRef.current ?? '') ?? 1));
+    list.style.transition = `transform ${shiftMs}ms cubic-bezier(0.22, 1, 0.36, 1)`;
     list.style.transform = '';
   });
 
@@ -688,6 +710,7 @@ function RouteComponent() {
             key={msg.id}
             msg={msg}
             exiting={fadeOut && now - getReceivedAtMs(msg) >= TTL_MS - EXIT_MS}
+            speed={speeds.get(msg.id) ?? 1}
             layout={search.layout}
             animation={search.animation}
             orientation={search.orientation}
@@ -714,6 +737,7 @@ function RouteComponent() {
 type MessageRowProps = {
   msg: ChatMessagesType;
   exiting: boolean;
+  speed: number;
   layout: LayoutChoice;
   animation: AnimationChoice;
   orientation: 'vertical' | 'horizontal';
@@ -738,6 +762,7 @@ type MessageRowProps = {
 const MessageRow = React.memo(function MessageRow({
   msg,
   exiting,
+  speed,
   layout,
   animation,
   orientation,
@@ -755,6 +780,9 @@ const MessageRow = React.memo(function MessageRow({
   boldUsernames,
   boldMessages,
 }: MessageRowProps) {
+  // Frozen at mount: a moderator deleting the previous message would otherwise change this row's
+  // speed mid-animation and make it jump (or un-type letters in typing mode).
+  const [mountSpeed] = React.useState(speed);
   const classes = LAYOUT_CLASSES[layout];
   const animClass = exiting ? 'animate-chat-fade-out' : ANIMATION_CLASSES[animation](orientation);
   const messageAnimClass = ANIMATION_MESSAGE_CLASSES[animation];
@@ -861,7 +889,11 @@ const MessageRow = React.memo(function MessageRow({
   const messageNode = (
     <span className={`${classes.message} ${messageAnimClass}`} style={messageStyle}>
       {layout === 'inline' || layout === 'compact' ? ' ' : null}
-      {animation === 'typing' ? <TypedContent nodes={parsedContent} /> : parsedContent}
+      {animation === 'typing' ? (
+        <TypedContent nodes={parsedContent} speed={mountSpeed} />
+      ) : (
+        parsedContent
+      )}
     </span>
   );
 
@@ -869,7 +901,7 @@ const MessageRow = React.memo(function MessageRow({
     <div
       data-msg-id={msg.id}
       className={`${classes.wrapper} ${itemBgClass} ${animClass} transform-gpu ${orientation === 'horizontal' ? 'flex-shrink-0' : ''}`}
-      style={wrapperStyle}
+      style={{ ...wrapperStyle, '--chat-speed': mountSpeed } as React.CSSProperties}
     >
       {isInlineOrCompact ? (
         <>

--- a/apps/extensions/src/routes/widgets/chat-widget.tsx
+++ b/apps/extensions/src/routes/widgets/chat-widget.tsx
@@ -365,12 +365,14 @@ export const Route = createFileRoute('/widgets/chat-widget')({
   },
 });
 
+// Both viewBoxes are cropped horizontally to the glyph's own bounds: the stock 24x24 boxes pad
+// Twitch 3 units but Kick only 1.33, so Kick sat visibly further left and closer to the badges.
 function TwitchIcon({ className, ...props }: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      className={`inline-block h-[1.15em] w-[1.15em] ${className ?? ''}`}
-      viewBox="0 0 24 24"
+      className={`inline-block h-[1.15em] w-auto ${className ?? ''}`}
+      viewBox="3 0 18.006 24"
       {...props}
     >
       <path
@@ -385,9 +387,9 @@ function KickIcon({ className, ...props }: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
       role="img"
-      viewBox="0 0 24 24"
+      viewBox="1.333 0 21.334 24"
       fill="currentColor"
-      className={`inline-block h-[1em] w-[1em] ${className ?? ''}`}
+      className={`inline-block h-[1em] w-auto ${className ?? ''}`}
       {...props}
     >
       <title>Kick</title>

--- a/apps/extensions/src/routes/widgets/chat-widget.tsx
+++ b/apps/extensions/src/routes/widgets/chat-widget.tsx
@@ -387,7 +387,7 @@ function KickIcon({ className, ...props }: React.SVGProps<SVGSVGElement>) {
       role="img"
       viewBox="0 0 24 24"
       fill="currentColor"
-      className={`inline-block h-[1.15em] w-[1.15em] ${className ?? ''}`}
+      className={`inline-block h-[1em] w-[1em] ${className ?? ''}`}
       {...props}
     >
       <title>Kick</title>

--- a/apps/extensions/src/styles.css
+++ b/apps/extensions/src/styles.css
@@ -45,7 +45,7 @@
 }
 
 .animate-chat-bounce-in {
-  animation: chatBounceIn 500ms ease-out forwards;
+  animation: chatBounceIn calc(500ms * var(--chat-speed, 1)) ease-out forwards;
 }
 
 @keyframes chatSlideIn {
@@ -60,7 +60,12 @@
 }
 
 .animate-chat-slide-in {
-  animation: chatSlideIn 380ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation: chatSlideIn 200ms ease-out both;
+}
+
+/* --chat-speed is set per row from how busy chat is (1 = calm); see getAnimationSpeeds. */
+.animate-chat-smooth-slide-in {
+  animation: chatSlideIn calc(380ms * var(--chat-speed, 1)) cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
 /* The easing already overshoots, so a mid-keyframe overshoot would double it. */
@@ -76,7 +81,7 @@
 }
 
 .animate-chat-pop-in {
-  animation: chatPopIn 380ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  animation: chatPopIn calc(380ms * var(--chat-speed, 1)) cubic-bezier(0.34, 1.56, 0.64, 1) both;
   transform-origin: right center;
 }
 
@@ -92,7 +97,7 @@
 }
 
 .animate-chat-stagger-meta {
-  animation: chatStaggerMeta 320ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation: chatStaggerMeta calc(320ms * var(--chat-speed, 1)) cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
 @keyframes chatStaggerMessage {
@@ -107,7 +112,8 @@
 }
 
 .animate-chat-stagger-message {
-  animation: chatStaggerMessage 320ms cubic-bezier(0.22, 1, 0.36, 1) 150ms both;
+  animation: chatStaggerMessage calc(320ms * var(--chat-speed, 1)) cubic-bezier(0.22, 1, 0.36, 1)
+    calc(150ms * var(--chat-speed, 1)) both;
 }
 
 @keyframes chatFadeIn {
@@ -120,7 +126,7 @@
 }
 
 .animate-chat-fade-in {
-  animation: chatFadeIn 350ms ease-out both;
+  animation: chatFadeIn calc(350ms * var(--chat-speed, 1)) ease-out both;
 }
 
 /* Box-shadow instead of an extra caret element: it paints outside the glyph without taking up

--- a/apps/extensions/src/styles.css
+++ b/apps/extensions/src/styles.css
@@ -60,17 +60,14 @@
 }
 
 .animate-chat-slide-in {
-  animation: chatSlideIn 200ms ease-out both;
+  animation: chatSlideIn 380ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
+/* The easing already overshoots, so a mid-keyframe overshoot would double it. */
 @keyframes chatPopIn {
   0% {
     opacity: 0;
-    transform: scale(0.6);
-  }
-  60% {
-    opacity: 1;
-    transform: scale(1.05);
+    transform: scale(0.85);
   }
   100% {
     opacity: 1;
@@ -79,7 +76,7 @@
 }
 
 .animate-chat-pop-in {
-  animation: chatPopIn 300ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  animation: chatPopIn 380ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
   transform-origin: right center;
 }
 
@@ -95,7 +92,7 @@
 }
 
 .animate-chat-stagger-meta {
-  animation: chatStaggerMeta 200ms ease-out both;
+  animation: chatStaggerMeta 320ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
 @keyframes chatStaggerMessage {
@@ -110,7 +107,7 @@
 }
 
 .animate-chat-stagger-message {
-  animation: chatStaggerMessage 200ms ease-out 250ms both;
+  animation: chatStaggerMessage 320ms cubic-bezier(0.22, 1, 0.36, 1) 150ms both;
 }
 
 @keyframes chatFadeIn {
@@ -123,7 +120,23 @@
 }
 
 .animate-chat-fade-in {
-  animation: chatFadeIn 200ms ease-out both;
+  animation: chatFadeIn 350ms ease-out both;
+}
+
+/* Box-shadow instead of an extra caret element: it paints outside the glyph without taking up
+   layout space, so it can't change where the half-typed line wraps. */
+.chat-typing-caret {
+  box-shadow: 2px 0 0 currentColor;
+}
+
+@keyframes chatFadeOut {
+  to {
+    opacity: 0;
+  }
+}
+
+.animate-chat-fade-out {
+  animation: chatFadeOut 400ms ease-in forwards;
 }
 
 /* Emote wall calm mode: fade in, drift away, fade out */


### PR DESCRIPTION
> **Stacked on #683.** Until #683 is merged, this PR also shows its 7 commits. The new commits here are `feat(extensions): redesign chat widget setup as a single-screen panel` and `fix(extensions): keep the newest horizontal chat messages on screen`. Please merge #683 first.

Rebuilds the chat widget setup page so the whole tool fits on one screen, with custom form controls instead of native selects and checkboxes, and inline explanations for settings that aren't obvious. **The widget URL format is unchanged**, so existing OBS browser sources keep working.

**Layout**
- Settings are grouped into Channel / Appearance / Messages on a two-column grid next to the live preview. Fits 1366×768 without scrolling. On shorter screens only the settings box scrolls, and its content stays inside the panel padding instead of running under the bottom edge.
- Compact header (logo, breadcrumb, title, free badge). The intro, OBS guide and FAQ moved below the tool and stay in the page for SEO.
- Settings that don't apply are disabled instead of hidden, so the layout doesn't jump: the Kick field when only Twitch is selected, the platform indicator unless both platforms are on, and the opacity slider while the dark background is off.
- The widget URL + copy button is a single block under the preview for every screen size. Previously it was duplicated for mobile and desktop.

**New shared controls (`components/ui`)**
- `Select`: listbox with arrow keys, Home/End, Enter/Space, Esc, typeahead and click-outside. It's portaled with fixed positioning so the scrollable panel can't clip it, and flips above the trigger when there's no room below.
- `Switch` (`role="switch"`), `SegmentedControl` (visually hidden native radios, so the browser handles arrow keys and tab stops), and `NumberField` with −/+ steppers and ArrowUp/Down.
- `InfoTip` (?): opens on mouse hover, keyboard focus, or tap on touch, and closes on Esc or an outside tap. It sits next to the label rather than inside it, so tapping the label still toggles the switch.
- No new dependencies.

**Tooltips**
- Platforms, channel name, platform indicator, orientation, dark background, 7TV emotes, badges, keep messages and animation get new tooltips. The existing always-visible hints (message box, color stripe, preview speed) moved into tooltips.
- Self-explanatory settings (font, size, bold, message time) have no tooltip.

**Code**
- The 19 separate `useState`s are now one settings object, and a single `buildWidgetParams` feeds both the widget URL and the preview URL. They used to be two copies of the same builder.
- Fixed: an emptied font size field produced `fontSize=0`, and a channel typed for a deselected platform produced a URL with no channel.
- Fixed: in horizontal orientation, once the messages filled the width, new ones landed off-screen to the right. The message list wrapper added in #683 could shrink to the screen width while its rows, which don't wrap, spilled past the right edge. It no longer shrinks, so the newest message always ends at the right edge.
- tr/en: new section and tooltip keys, `moreInfo` for the (?) button's label, `chatWidget.both` shortened to "Both"/"İkisi" for the segmented control, and the unused `styleSection` removed.

**Testing**
- `tsc`, `biome check` and `vitest` (99 tests) pass.
- Checked in Chrome at 1440×900, 1366×768 and 400px wide, in dark and light themes. Covered keyboard selection in the dropdowns, tooltip hover, the font size stepper, and the generated widget URL params.
