### PR TITLE
fix(extensions): stop OBS bridge reconnect attempts from doubling

### DIFF
--- a/apps/extensions/src/features/tools/use-chat.test.ts
+++ b/apps/extensions/src/features/tools/use-chat.test.ts
@@ -1,0 +1,54 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useChat } from './use-chat';
+
+const { connect } = vi.hoisted(() => ({ connect: vi.fn() }));
+
+// Like obs-websocket-js 5: a refused connect fires ConnectionClosed and then rejects, and
+// disconnect() fires ConnectionClosed too.
+vi.mock('obs-websocket-js', () => ({
+  OBSWebSocket: class {
+    private handlers = new Map<string, () => void>();
+    on(event: string, handler: () => void) {
+      this.handlers.set(event, handler);
+    }
+    async connect() {
+      connect();
+      this.handlers.get('ConnectionClosed')?.();
+      throw new Error('connection refused');
+    }
+    async disconnect() {
+      this.handlers.get('ConnectionClosed')?.();
+    }
+    async call() {}
+  },
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  connect.mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useChat OBS connection', () => {
+  it('retries once every 5s while OBS refuses the connection', async () => {
+    renderHook(() => useChat('Main', 'BRB'));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(connect).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(connect).toHaveBeenCalledTimes(5);
+  });
+
+  it('stops retrying after unmount', async () => {
+    const { unmount } = renderHook(() => useChat('Main', 'BRB'));
+    await vi.advanceTimersByTimeAsync(0);
+    unmount();
+
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/extensions/src/features/tools/use-chat.ts
+++ b/apps/extensions/src/features/tools/use-chat.ts
@@ -73,6 +73,7 @@ export const useChat = (
     const obs = new OBSWebSocket();
     const statusElId = "obs-status";
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let disposed = false;
 
     const updateUI = (text: string, color: string) => {
       const el = document.getElementById(statusElId);
@@ -94,6 +95,16 @@ export const useChat = (
       }
     };
 
+    // A failed connect both rejects and fires ConnectionClosed. Each used to start its own retry,
+    // doubling the attempts every round; now they share one pending retry.
+    const scheduleReconnect = () => {
+      if (disposed || reconnectTimer) return;
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        connectOBS();
+      }, 5000);
+    };
+
     const connectOBS = async () => {
       try {
         if (!obsWebsocketUrl) {
@@ -104,16 +115,18 @@ export const useChat = (
         updateUI("Connected", "green");
         onConnectedRef.current?.(true);
       } catch {
+        if (disposed) return;
         updateUI("Connection Failed, Retrying...", "red");
         onConnectedRef.current?.(false);
-        reconnectTimer = setTimeout(connectOBS, 5000);
+        scheduleReconnect();
       }
     };
 
     obs.on('ConnectionClosed', () => {
+      if (disposed) return;
       updateUI("Disconnected, Reconnecting...", "red");
       onConnectedRef.current?.(false);
-      reconnectTimer = setTimeout(connectOBS, 5000);
+      scheduleReconnect();
     });
 
     obs.on('Identified', async () => {
@@ -187,6 +200,8 @@ export const useChat = (
     }
 
     return () => {
+      // Set before disconnect(), whose ConnectionClosed would otherwise schedule a retry.
+      disposed = true;
       if (reconnectTimer) clearTimeout(reconnectTimer);
       for (const client of clients) {
         client.disconnect();


### PR DESCRIPTION
While OBS is closed or the password is wrong, the OBS bridge retried more often every round instead of once every 5s.

**Why:** in obs-websocket-js 5, a refused `connect()` fires `ConnectionClosed` and then rejects. `useChat` started a retry in both the `ConnectionClosed` handler and the `catch`, so each failed attempt started two more: 1, 2, 4, 8… attempts per round. That's 31 connects in 20s, and it passes 100k in under a minute and a half.

Unmounting had a second leak: `obs.disconnect()` also fires `ConnectionClosed`, which scheduled a retry after the cleanup had already cleared the timer, so the bridge kept connecting after the page moved on.

**Fix** (`features/tools/use-chat.ts`)
- Both paths call `scheduleReconnect`, which keeps at most one retry pending.
- A `disposed` flag, set before `disconnect()`, stops retries after unmount and keeps a late failure from the old connection from flipping the status of the new one (React StrictMode mounts twice).

**Testing**
- New `use-chat.test.ts` with an OBS mock that behaves like obs-websocket-js 5 (refused connect: `ConnectionClosed`, then reject; `disconnect()` fires `ConnectionClosed`). Before the fix: 31 connects in 20s, still going after unmount. After: 5 in 20s (one every 5s), none after unmount.
- `vitest` (101) and `biome lint` (changed files) pass. `tsc` shows only the known `/widgets/alerts` route tree errors on `dev`, unrelated to this PR.
