### PR TITLE
fix(extensions): keep chat widget up when a username color is an Object key

### DIFF
--- a/apps/extensions/src/features/widgets/chat-widget/color-utils.test.ts
+++ b/apps/extensions/src/features/widgets/chat-widget/color-utils.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { getAccessibleColor } from './color-utils';
+
+describe('getAccessibleColor', () => {
+  it('reads hex and named colors', () => {
+    expect(getAccessibleColor('#ffffff')).toBe('rgb(255, 255, 255)');
+    expect(getAccessibleColor('White')).toBe('rgb(255, 255, 255)');
+  });
+
+  it('passes through unknown colors, including Object.prototype names', () => {
+    for (const color of ['constructor', '__proto__', 'toString', 'rebeccapurple']) {
+      expect(getAccessibleColor(color)).toBe(color);
+    }
+  });
+});

--- a/apps/extensions/src/features/widgets/chat-widget/color-utils.ts
+++ b/apps/extensions/src/features/widgets/chat-widget/color-utils.ts
@@ -23,7 +23,9 @@ const NAMED_COLORS: Record<string, string> = {
 };
 
 function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
-  const clean = NAMED_COLORS[hex.toLowerCase()] || hex.trim();
+  // hasOwn, not a plain lookup: "constructor" or "__proto__" would return a function or object.
+  const name = hex.toLowerCase();
+  const clean = Object.hasOwn(NAMED_COLORS, name) ? NAMED_COLORS[name] : hex.trim();
   const match = clean.match(/^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i);
   if (match) {
     return {


### PR DESCRIPTION
`getAccessibleColor` looked up named colors on a plain object, so a message color of `constructor`, `__proto__` or `toString` returned a function or `Object.prototype` instead of a hex string. `.match` then threw and the chat widget fell to its error screen, on stream.

The way in was the Twitch parser reading a fake line typed into a resub message, with a `color` tag the viewer wrote. #687 closes that, and Twitch and Kick only send hex colors themselves, so this is the second layer: a single odd value shouldn't be able to take the whole widget down.

**Fix** (`features/widgets/chat-widget/color-utils.ts`): only `Object.hasOwn` keys count as named colors; anything else goes through the same path as before.

**Testing**
- New `color-utils.test.ts`: hex and named colors still convert; `constructor`, `__proto__`, `toString` and an unknown name come back unchanged. The Object-key case threw `clean.match is not a function` before the fix.
- `vitest` (101) and `biome lint` (changed files) pass. `tsc` shows only the known `/widgets/alerts` route tree errors on `dev`, unrelated.
