### PR TITLE
fix(extensions): show the channel's own 7TV emotes in chat widget and emote wall

### DIFF
--- a/apps/extensions/src/features/widgets/chat-widget/use-7tv-emotes.test.ts
+++ b/apps/extensions/src/features/widgets/chat-widget/use-7tv-emotes.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetch7tvEmotes } from './use-7tv-emotes';
+
+const respond = (routes: Record<string, { status?: number; body?: unknown }>) => {
+  const fetchMock = vi.fn(async (url: string) => {
+    const route = Object.entries(routes).find(([prefix]) => url.startsWith(prefix))?.[1];
+    if (!route) {
+      return new Response('{}', { status: 404 });
+    }
+    return new Response(JSON.stringify(route.body ?? {}), { status: route.status ?? 200 });
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('fetch7tvEmotes', () => {
+  it("reads the active emote set of the channel's own 7TV account", async () => {
+    const fetchMock = respond({
+      'https://api.ivr.fi/v2/twitch/user?login=channel': { body: [{ id: '123', login: 'channel' }] },
+      'https://7tv.io/v3/users/twitch/123': {
+        body: {
+          emote_set: {
+            emotes: [
+              { id: 'e1', name: 'catJAM' },
+              { id: 'e2', name: '', data: { name: 'peepoHappy' } },
+            ],
+          },
+        },
+      },
+    });
+
+    const map = await fetch7tvEmotes(' Channel ');
+    expect([...map]).toEqual([
+      ['catJAM', 'e1'],
+      ['peepoHappy', 'e2'],
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns no emotes when the channel has no 7TV account', async () => {
+    respond({
+      'https://api.ivr.fi/v2/twitch/user?login=channel': { body: [{ id: '123' }] },
+      'https://7tv.io/v3/users/twitch/123': { status: 404, body: { error: 'user not found' } },
+    });
+    expect((await fetch7tvEmotes('channel')).size).toBe(0);
+  });
+
+  it('returns no emotes when the Twitch channel does not exist', async () => {
+    const fetchMock = respond({ 'https://api.ivr.fi/v2/twitch/user?login=nobody': { body: [] } });
+    expect((await fetch7tvEmotes('nobody')).size).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/extensions/src/features/widgets/chat-widget/use-7tv-emotes.ts
+++ b/apps/extensions/src/features/widgets/chat-widget/use-7tv-emotes.ts
@@ -6,22 +6,41 @@ type SevenTVEmote = {
   data?: { name?: string };
 };
 
-type SevenTVEmoteSet = {
-  id: string;
-  name: string;
-  emotes?: SevenTVEmote[];
+type SevenTVConnection = {
+  emote_set?: {
+    emotes?: SevenTVEmote[];
+  } | null;
 };
 
-type SevenTVUser = {
-  id: string;
-  emote_sets?: SevenTVEmoteSet[];
-};
+// 7TV's user search is fuzzy ("forsen" returns other accounts first), so the channel is looked up
+// by its Twitch ID, and only the emote set active on that channel is read.
+export async function fetch7tvEmotes(twitchChannel: string): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  try {
+    const userResponse = await fetch(
+      `https://api.ivr.fi/v2/twitch/user?login=${encodeURIComponent(twitchChannel.trim().toLowerCase())}`,
+      { headers: { Accept: "application/json" } },
+    );
+    if (!userResponse.ok) return map;
+    const [twitchUser] = (await userResponse.json()) as { id?: string }[];
+    if (!twitchUser?.id) return map;
 
-type SevenTVResponse = {
-  data?: {
-    users?: SevenTVUser[];
-  };
-};
+    // 404 when the channel has no 7TV account.
+    const response = await fetch(`https://7tv.io/v3/users/twitch/${twitchUser.id}`);
+    if (!response.ok) return map;
+
+    const connection = (await response.json()) as SevenTVConnection;
+    for (const emote of connection.emote_set?.emotes || []) {
+      const name = emote.name || emote.data?.name;
+      if (name && emote.id) {
+        map.set(name, emote.id);
+      }
+    }
+  } catch {
+    // Silently fail — 7tv emotes are optional
+  }
+  return map;
+}
 
 export const use7tvEmotes = (twitchChannel?: string | null) => {
   const [emoteMap, setEmoteMap] = React.useState<Map<string, string>>(
@@ -35,61 +54,11 @@ export const use7tvEmotes = (twitchChannel?: string | null) => {
     }
 
     let cancelled = false;
-
-    const fetchEmotes = async () => {
-      try {
-        const query = `
-          query SearchUsers {
-            users(query: "${twitchChannel}", limit: 1) {
-              id
-              emote_sets {
-                id
-                name
-                emotes {
-                  id
-                  name
-                  data {
-                    name
-                  }
-                }
-              }
-            }
-          }
-        `;
-
-        const response = await fetch("https://7tv.io/v3/gql", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ query }),
-        });
-
-        if (!response.ok) return;
-
-        const json = (await response.json()) as SevenTVResponse;
-        const users = json?.data?.users;
-        if (!users || users.length === 0) return;
-
-        const user = users[0];
-        const map = new Map<string, string>();
-
-        for (const emoteSet of user?.emote_sets || []) {
-          for (const emote of emoteSet.emotes || []) {
-            const name = emote.name || emote.data?.name;
-            if (name && emote.id) {
-              map.set(name, emote.id);
-            }
-          }
-        }
-
-        if (!cancelled) {
-          setEmoteMap(map);
-        }
-      } catch {
-        // Silently fail — 7tv emotes are optional
+    fetch7tvEmotes(twitchChannel).then((map) => {
+      if (!cancelled) {
+        setEmoteMap(map);
       }
-    };
-
-    fetchEmotes();
+    });
 
     return () => {
       cancelled = true;


### PR DESCRIPTION
The chat widget and emote wall looked the channel up with 7TV's `users(query: "<channel>", limit: 1)`. That's a fuzzy search, so the first hit is often a different account: on the live API, `senchabot` returns `sencha_vt` and `forsen` returns `21mtd`. Neither channel has a 7TV account, so every hit is someone else's. Streamers could get a stranger's emotes, and channels without 7TV always did.

It also merged every emote set that account owned, including inactive ones (Halloween, Christmas…). When two sets had an emote with the same name, the later one won, so an emote could show the wrong image.

**Fix** (`features/widgets/chat-widget/use-7tv-emotes.ts`)
- Resolve the channel's Twitch ID with `api.ivr.fi/v2/twitch/user?login=` (ivr.fi is already used for badges in `use-badges.ts`), then read `7tv.io/v3/users/twitch/{id}`, whose `emote_set` is the set active on that channel.
- Channel without a 7TV account (404) or unknown channel: no 7TV emotes.
- A failed fetch now sets an empty map instead of keeping the previous channel's emotes.
- The channel name is no longer pasted into a GraphQL query string.

**Behavior change:** channels only get the emotes in their active 7TV set, which is what their chat shows with the 7TV extension.

**Testing**
- New `use-7tv-emotes.test.ts` (mocked fetch): active set read with both `name` and `data.name`, no 7TV account, unknown Twitch channel.
- Live check through the new code: xqc 962, pokimane 722, zackrawrr 999 emotes from each one's own set; forsen, senchabot and elraenn have no 7TV account (7TV answers 404 for their Twitch IDs) and get none.
- `vitest` (102) and `biome lint` (changed files) pass. `tsc` shows only the known `/widgets/alerts` route tree errors on `dev`, unrelated.

