### PR TITLE
fix(extensions): stop the alerts widget from stalling after a burst of alerts

### DIFF
--- a/apps/extensions/src/features/widgets/alerts/use-alert-queue.test.ts
+++ b/apps/extensions/src/features/widgets/alerts/use-alert-queue.test.ts
@@ -1,0 +1,46 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DISPLAY_DURATION, MAX_VISIBLE } from '#/lib/alert-config';
+import { useAlertQueue } from './use-alert-queue';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+const addFollows = (addAlert: ReturnType<typeof useAlertQueue>['addAlert'], count: number) => {
+  act(() => {
+    for (let i = 0; i < count; i++) {
+      addAlert('follow', { name: `follower${i}`, platform: 'kick' });
+    }
+  });
+};
+
+describe('useAlertQueue', () => {
+  it('shows up to MAX_VISIBLE alerts and queues the rest', () => {
+    const { result } = renderHook(() => useAlertQueue());
+    addFollows(result.current.addAlert, MAX_VISIBLE + 3);
+    expect(result.current.visibleAlerts.map((a) => a.data.name)).toEqual(
+      ['follower0', 'follower1', 'follower2', 'follower3', 'follower4'],
+    );
+  });
+
+  it('removes alerts that came from the queue too, so a burst drains', () => {
+    const { result } = renderHook(() => useAlertQueue());
+    addFollows(result.current.addAlert, MAX_VISIBLE * 2);
+
+    act(() => vi.advanceTimersByTime(DISPLAY_DURATION));
+    expect(result.current.visibleAlerts.map((a) => a.data.name)).toEqual(
+      ['follower5', 'follower6', 'follower7', 'follower8', 'follower9'],
+    );
+
+    act(() => vi.advanceTimersByTime(DISPLAY_DURATION));
+    expect(result.current.visibleAlerts).toEqual([]);
+
+    addFollows(result.current.addAlert, 1);
+    expect(result.current.visibleAlerts.map((a) => a.data.name)).toEqual(['follower0']);
+  });
+});

--- a/apps/extensions/src/features/widgets/alerts/use-alert-queue.ts
+++ b/apps/extensions/src/features/widgets/alerts/use-alert-queue.ts
@@ -42,15 +42,18 @@ export function useAlertQueue() {
     timersRef.current.delete(id);
   }, []);
 
-  const scheduleRemoval = useCallback(
-    (id: string) => {
-      const timer = window.setTimeout(() => {
-        removeAlert(id);
-      }, DISPLAY_DURATION);
-      timersRef.current.set(id, timer);
-    },
-    [removeAlert],
-  );
+  // Timers follow what is on screen. Scheduling only in addAlert missed alerts promoted from the
+  // queue, which then stayed forever; five of them filled the screen and stalled the queue.
+  useEffect(() => {
+    for (const alert of state.visible) {
+      if (!timersRef.current.has(alert.id)) {
+        const timer = window.setTimeout(() => {
+          removeAlert(alert.id);
+        }, DISPLAY_DURATION);
+        timersRef.current.set(alert.id, timer);
+      }
+    }
+  }, [state.visible, removeAlert]);
 
   const addAlert = useCallback(
     (type: AlertType, data: AlertEvent['data']) => {
@@ -63,7 +66,6 @@ export function useAlertQueue() {
 
       setState((prev) => {
         if (prev.visible.length < MAX_VISIBLE) {
-          scheduleRemoval(newAlert.id);
           return {
             visible: [...prev.visible, newAlert],
             queue: prev.queue,
@@ -75,7 +77,7 @@ export function useAlertQueue() {
         };
       });
     },
-    [scheduleRemoval],
+    [],
   );
 
   return {


### PR DESCRIPTION
The alerts widget shows up to 5 alerts and queues the rest. Only alerts that went straight on screen got a removal timer; one moved up from the queue never did. After the first burst of more than 5 alerts, the queued ones filled the screen, never left, and every later alert waited in the queue forever. Ten quick follows (a cheap follow bot is enough) stopped the widget until the page was reloaded.

**Fix** (`features/widgets/alerts/use-alert-queue.ts`)
- An effect starts a timer for every visible alert that doesn't have one, so it no longer matters how an alert got on screen.
- `addAlert`'s `setState` updater no longer starts timers. Updaters run twice under StrictMode, which started a second, untracked timer.

**Testing**
- New `use-alert-queue.test.ts`: 8 alerts show 5 and queue 3; a burst of 10 shows 5, then the next 5, then none, and a new alert shows right away. The drain case failed before the fix (5 alerts stuck on screen).
- `vitest` and `biome lint` (changed files) pass. `tsc` shows only the known `/widgets/alerts` route tree errors on `dev`, unrelated.
