### PR TITLE
fix(extensions): tie OBS bridge command users to the platform they chat on

### DIFF
--- a/apps/extensions/llms.txt
+++ b/apps/extensions/llms.txt
@@ -184,10 +184,10 @@ A local WebSocket bridge that allows streamers and authorized channel moderators
   - `cmdBack`: Switch to Main scene (default: `back`, can be `main`, `imback`).
   - `cmdStartStream` & `cmdStopStream`: Stream management (default: `!startstream` / `!stopstream`, can be `start` / `stop`).
   - `cmdStartRecord` & `cmdStopRecord`: Recording management (default: `!startrecord` / `!stoprecord`, can be `rec` / `stoprec`).
-- **User Whitelist (`commandUser`)**: Comma-separated username whitelist ensuring only authorized moderators or broadcasters can execute OBS commands.
+- **User Whitelist (`commandUser`)**: Comma-separated whitelist of `platform:username` entries (e.g. `twitch:bob,kick:alice`) ensuring only authorized moderators or broadcasters can execute OBS commands, and only from the platform they were added for. Older entries without a platform count for the only platform set up; when both Twitch and Kick are set up they are ignored until a platform is picked on the tool page.
 - **Scene Assignment Interface**: Interactive scene selector allowing broadcasters to assign `Main` and `BRB` scenes dynamically from their live OBS scene list.
 - **URL Query Parameters**:
-  - `twitch` (string), `kick` (string), `commandUser` (comma-separated usernames)
+  - `twitch` (string), `kick` (string), `commandUser` (comma-separated `platform:username` entries)
   - `obsWebsocketUrl` (string, default: `ws://localhost:4455`), `obsWebsocketPassword` (string)
   - `mainScene` (string), `brbScene` (string)
   - `cmdScene`, `cmdBrb`, `cmdBack`, `cmdStartStream`, `cmdStopStream`, `cmdStartRecord`, `cmdStopRecord`

--- a/apps/extensions/src/features/tools/command-users.test.ts
+++ b/apps/extensions/src/features/tools/command-users.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  commandUserKey,
+  formatCommandUsers,
+  parseCommandUsers,
+  resolveCommandUsers,
+} from './command-users';
+
+const both = { twitch: true, kick: true };
+
+describe('parseCommandUsers', () => {
+  it('reads platform-tagged and old untagged names', () => {
+    expect(parseCommandUsers(' Twitch:Bob , kick:ali,carol,,twitch:bob')).toEqual([
+      { platform: 'twitch', name: 'bob' },
+      { platform: 'kick', name: 'ali' },
+      { platform: null, name: 'carol' },
+    ]);
+  });
+
+  it('keeps the same name on both platforms as two users', () => {
+    expect(parseCommandUsers('twitch:bob,kick:bob')).toHaveLength(2);
+  });
+
+  it('round-trips through formatCommandUsers', () => {
+    const raw = 'twitch:bob,kick:ali,carol';
+    expect(formatCommandUsers(parseCommandUsers(raw))).toBe(raw);
+  });
+
+  it('returns nothing for an empty param', () => {
+    expect(parseCommandUsers(undefined)).toEqual([]);
+    expect(parseCommandUsers('')).toEqual([]);
+  });
+});
+
+describe('resolveCommandUsers', () => {
+  it('only lets a name run commands on the platform it was saved with', () => {
+    const { allowed } = resolveCommandUsers(parseCommandUsers('twitch:bob'), both);
+    expect(allowed.has(commandUserKey('twitch', 'Bob'))).toBe(true);
+    expect(allowed.has(commandUserKey('kick', 'bob'))).toBe(false);
+  });
+
+  it('gives an untagged name the only platform the link listens to', () => {
+    const users = parseCommandUsers('bob');
+    expect([...resolveCommandUsers(users, { twitch: true, kick: false }).allowed]).toEqual([
+      'twitch:bob',
+    ]);
+    expect([...resolveCommandUsers(users, { twitch: false, kick: true }).allowed]).toEqual([
+      'kick:bob',
+    ]);
+  });
+
+  it('leaves untagged names out while both platforms are set up', () => {
+    const { allowed, unassigned } = resolveCommandUsers(
+      parseCommandUsers('bob,kick:ali'),
+      both,
+    );
+    expect([...allowed]).toEqual(['kick:ali']);
+    expect(unassigned).toEqual(['bob']);
+  });
+});

--- a/apps/extensions/src/features/tools/command-users.ts
+++ b/apps/extensions/src/features/tools/command-users.ts
@@ -1,0 +1,50 @@
+import type { ChatMessagesType } from "../widgets/chat-widget/chat-messages";
+
+export type ChatPlatform = ChatMessagesType["platform"];
+
+// platform is null for names saved before the list had platforms ("bob" instead of "twitch:bob").
+export type CommandUser = { platform: ChatPlatform | null; name: string };
+
+const PLATFORMS: readonly ChatPlatform[] = ["twitch", "kick"];
+
+export function commandUserKey(platform: ChatPlatform, name: string): string {
+  return `${platform}:${name.trim().toLowerCase()}`;
+}
+
+export function parseCommandUsers(raw: string | null | undefined): CommandUser[] {
+  const users: CommandUser[] = [];
+  for (const entry of raw?.split(",") ?? []) {
+    const [prefix, ...rest] = entry.split(":");
+    const platform = PLATFORMS.find((p) => p === prefix.trim().toLowerCase());
+    const name = (platform ? rest.join(":") : entry).trim().toLowerCase();
+    if (name && !users.some((u) => u.platform === (platform ?? null) && u.name === name)) {
+      users.push({ platform: platform ?? null, name });
+    }
+  }
+  return users;
+}
+
+export function formatCommandUsers(users: CommandUser[]): string {
+  return users.map((u) => (u.platform ? `${u.platform}:${u.name}` : u.name)).join(",");
+}
+
+// A name without a platform is only unambiguous when the link sets up a single platform. With both,
+// "bob" could be anyone who takes that name on the other one, so it is left out until a platform is
+// picked.
+export function resolveCommandUsers(
+  users: CommandUser[],
+  platforms: { twitch: boolean; kick: boolean },
+): { allowed: Set<string>; unassigned: string[] } {
+  const configured = PLATFORMS.filter((p) => platforms[p]);
+  const allowed = new Set<string>();
+  const unassigned: string[] = [];
+  for (const user of users) {
+    const platform = user.platform ?? (configured.length === 1 ? configured[0] : null);
+    if (platform) {
+      allowed.add(commandUserKey(platform, user.name));
+    } else if (configured.length > 1) {
+      unassigned.push(user.name);
+    }
+  }
+  return { allowed, unassigned };
+}

--- a/apps/extensions/src/features/tools/platform-picker.tsx
+++ b/apps/extensions/src/features/tools/platform-picker.tsx
@@ -1,0 +1,44 @@
+import type { ChatPlatform } from "./command-users";
+
+const PLATFORMS: { id: ChatPlatform; label: string; active: string; text: string }[] = [
+  { id: "twitch", label: "Twitch", active: "bg-purple-600 text-white", text: "text-purple-600 dark:text-purple-400" },
+  { id: "kick", label: "Kick", active: "bg-green-600 text-white", text: "text-green-600 dark:text-green-400" },
+];
+
+export function PlatformPicker({
+  value,
+  onChange,
+  label,
+}: {
+  value: ChatPlatform;
+  onChange: (platform: ChatPlatform) => void;
+  label: string;
+}) {
+  return (
+    <fieldset
+      aria-label={label}
+      className="m-0 flex shrink-0 overflow-hidden rounded-md border border-zinc-300 p-0 text-xs dark:border-zinc-700"
+    >
+      {PLATFORMS.map((p) => (
+        <button
+          key={p.id}
+          type="button"
+          aria-pressed={value === p.id}
+          onClick={() => onChange(p.id)}
+          className={`px-2.5 font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-green-500 ${
+            value === p.id
+              ? p.active
+              : "bg-zinc-100 text-zinc-600 hover:text-zinc-900 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:text-white"
+          }`}
+        >
+          {p.label}
+        </button>
+      ))}
+    </fieldset>
+  );
+}
+
+export function PlatformTag({ platform }: { platform: ChatPlatform }) {
+  const p = PLATFORMS.find((x) => x.id === platform);
+  return p ? <span className={`font-semibold ${p.text}`}>{p.label}</span> : null;
+}

--- a/apps/extensions/src/features/tools/use-chat-command-users.test.ts
+++ b/apps/extensions/src/features/tools/use-chat-command-users.test.ts
@@ -1,0 +1,77 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ChatMessagesType } from '../widgets/chat-widget/chat-messages';
+import { parseCommandUsers, resolveCommandUsers } from './command-users';
+import { useChat } from './use-chat';
+
+const { obsCall, chat } = vi.hoisted(() => ({
+  obsCall: vi.fn(),
+  chat: {} as Record<'twitch' | 'kick', (m: ChatMessagesType) => void>,
+}));
+
+vi.mock('obs-websocket-js', () => ({
+  OBSWebSocket: class {
+    on() {}
+    async connect() {}
+    async disconnect() {}
+    async call(request: string) {
+      obsCall(request);
+    }
+  },
+}));
+
+vi.mock('#/lib/twitch', () => ({
+  TwitchChat: class {
+    constructor(_channel: string, onMessage: (m: ChatMessagesType) => void) {
+      chat.twitch = onMessage;
+    }
+    disconnect() {}
+  },
+}));
+
+vi.mock('#/lib/kick', () => ({
+  KickChat: class {
+    constructor(_channel: string, onMessage: (m: ChatMessagesType) => void) {
+      chat.kick = onMessage;
+    }
+    disconnect() {}
+  },
+}));
+
+const say = (platform: 'twitch' | 'kick', user: string, message: string) => {
+  const now = new Date();
+  chat[platform]({ id: `${platform}-${user}`, platform, user, message, timestamp: now, receivedAt: now });
+};
+
+const bridge = (commandUser: string) => {
+  const allowed = resolveCommandUsers(parseCommandUsers(commandUser), {
+    twitch: true,
+    kick: true,
+  }).allowed;
+  renderHook(() => useChat('Main', 'BRB', 'channel', '1', null, undefined, allowed));
+};
+
+beforeEach(() => {
+  obsCall.mockClear();
+});
+
+describe('useChat command users', () => {
+  it('runs a command from the allowed user on the platform they were added for', () => {
+    bridge('twitch:bob');
+    say('twitch', 'Bob', '!stopstream');
+    expect(obsCall).toHaveBeenCalledWith('StopStream');
+  });
+
+  it('ignores the same name on the other platform', () => {
+    bridge('twitch:bob');
+    say('kick', 'bob', '!stopstream');
+    expect(obsCall).not.toHaveBeenCalled();
+  });
+
+  it('ignores an old untagged name while both platforms are connected', () => {
+    bridge('bob');
+    say('twitch', 'bob', '!stopstream');
+    say('kick', 'bob', '!stopstream');
+    expect(obsCall).not.toHaveBeenCalled();
+  });
+});

--- a/apps/extensions/src/features/tools/use-chat.ts
+++ b/apps/extensions/src/features/tools/use-chat.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import { TwitchChat } from "#/lib/twitch";
 import { KickChat } from "#/lib/kick";
 import type { ChatMessagesType } from "../widgets/chat-widget/chat-messages";
+import { commandUserKey } from "./command-users";
 import { OBSWebSocket } from 'obs-websocket-js';
 
 type Disconnectable = {
@@ -28,15 +29,6 @@ export const DEFAULT_OBS_COMMANDS: Required<ObsBridgeCustomCommands> = {
   cmdScene: "!scene",
 };
 
-function parseUsers(raw: string | null | undefined): Set<string> {
-  return new Set(
-    raw ? raw
-      .split(",")
-      .map(u => u.trim().toLowerCase())
-      .filter(Boolean): [],
-  );
-}
-
 export const useChat = (
   mainScene: string,
   brbScene: string,
@@ -44,7 +36,8 @@ export const useChat = (
   kickChannelId?: string | null,
   obsWebsocketUrl?: string | null,
   obsWebsocketPassword?: string | undefined,
-  commandUser?: string | null,
+  // commandUserKey values, from resolveCommandUsers.
+  commandUsers: ReadonlySet<string> = new Set(),
   onScenes?: (scenes: string[]) => void,
   onConnected?: (connected: boolean) => void,
   customCommands?: ObsBridgeCustomCommands,
@@ -57,8 +50,8 @@ export const useChat = (
   mainSceneRef.current = mainScene;
   const brbSceneRef = useRef(brbScene);
   brbSceneRef.current = brbScene;
-  const cmdUsersRef = useRef(parseUsers(commandUser));
-  cmdUsersRef.current = parseUsers(commandUser);
+  const cmdUsersRef = useRef(commandUsers);
+  cmdUsersRef.current = commandUsers;
   const scenesRef = useRef<string[]>([]);
   const customCommandsRef = useRef({
     ...DEFAULT_OBS_COMMANDS,
@@ -127,7 +120,7 @@ export const useChat = (
     connectOBS();
 
     const pushToMessages = (payload: ChatMessagesType) => {
-      if (!cmdUsersRef.current.has(payload.user.toLowerCase())) return;
+      if (!cmdUsersRef.current.has(commandUserKey(payload.platform, payload.user))) return;
 
       const rawMsg = payload.message.trim();
       const msg = rawMsg.toLowerCase();

--- a/apps/extensions/src/lib/i18n/en.ts
+++ b/apps/extensions/src/lib/i18n/en.ts
@@ -125,7 +125,8 @@ export const en = {
     twitchChannel: 'Twitch Channel (to listen in)',
     kickChannel: 'Kick Channel (to listen in)',
     authorizedUsers: 'Authorized Users',
-    authorizedHint: "Only these users' chat messages will trigger OBS actions.",
+    authorizedHint: 'Only these users can trigger OBS actions from chat, and only on the platform you picked for each.',
+    userPlatform: 'Platform',
     customCommands: 'Custom Command Names',
     customCommandsHint:
       'Customize the chat trigger words for each action (e.g. change !scene to scene or !startstream to start).',
@@ -290,6 +291,9 @@ export const en = {
     assignHintRest: 'next to a scene to assign it. Or switch to any scene using',
     commandUsers: 'Command Users ({count})',
     addUsername: 'Add username',
+    userPlatform: 'Platform',
+    pickPlatformWarning:
+      "Twitch and Kick are both connected, so pick a platform for each yellow name. They can't run commands until you do.",
     add: 'Add',
     activeCommands: 'Active Chat Commands',
     cmdScene: 'Switch to Any Scene:',

--- a/apps/extensions/src/lib/i18n/tr.ts
+++ b/apps/extensions/src/lib/i18n/tr.ts
@@ -128,7 +128,8 @@ export const tr: typeof en = {
     twitchChannel: 'Twitch Kanalı (dinlenecek)',
     kickChannel: 'Kick Kanalı (dinlenecek)',
     authorizedUsers: 'Yetkili Kullanıcılar',
-    authorizedHint: 'Sadece bu kullanıcıların sohbet mesajları OBS eylemlerini tetikler.',
+    authorizedHint: 'Sohbetten OBS eylemlerini sadece bu kullanıcılar tetikleyebilir, o da her biri için seçtiğin platformda.',
+    userPlatform: 'Platform',
     customCommands: 'Özel Komut Adları',
     customCommandsHint:
       'Her eylem için sohbet tetikleyici kelimelerini özelleştir (örn. !scene yerine scene, !startstream yerine start kullan).',
@@ -297,6 +298,9 @@ export const tr: typeof en = {
     assignHintRest: 'düğmesine tıkla. Ya da !scene <ad> komutuyla herhangi bir sahneye geç.',
     commandUsers: 'Komut Kullanıcıları ({count})',
     addUsername: 'Kullanıcı adı ekle',
+    userPlatform: 'Platform',
+    pickPlatformWarning:
+      'Twitch ve Kick ikisi de bağlı, sarı görünen her isim için bir platform seç. Seçene kadar komut kullanamazlar.',
     add: 'Ekle',
     activeCommands: 'Aktif Sohbet Komutları',
     cmdScene: 'Herhangi Bir Sahneye Geç:',

--- a/apps/extensions/src/routes/setup/obs-bridge.tsx
+++ b/apps/extensions/src/routes/setup/obs-bridge.tsx
@@ -1,5 +1,11 @@
 import { Breadcrumb } from "#/components/breadcrumb";
 import { YoutubeTutorial } from "#/components/youtube-tutorial";
+import {
+  type ChatPlatform,
+  type CommandUser,
+  formatCommandUsers,
+} from "#/features/tools/command-users";
+import { PlatformPicker, PlatformTag } from "#/features/tools/platform-picker";
 import { useT } from "#/lib/i18n";
 import { getLocaleLinks } from "#/lib/i18n/seo";
 import { createFileRoute, Link } from "@tanstack/react-router";
@@ -108,17 +114,21 @@ export const Route = createFileRoute("/setup/obs-bridge")({
 function CommandUserInput({
   users,
   onChange,
+  defaultPlatform,
 }: {
-  users: string[];
-  onChange: (users: string[]) => void;
+  users: CommandUser[];
+  onChange: (users: CommandUser[]) => void;
+  defaultPlatform: ChatPlatform;
 }) {
   const t = useT();
   const [input, setInput] = useState("");
+  const [picked, setPicked] = useState<ChatPlatform | null>(null);
+  const platform = picked ?? defaultPlatform;
 
   const handleAdd = () => {
     const name = input.trim().toLowerCase();
-    if (name && !users.includes(name)) {
-      onChange([...users, name]);
+    if (name && !users.some((u) => u.platform === platform && u.name === name)) {
+      onChange([...users, { platform, name }]);
       setInput("");
     }
   };
@@ -131,10 +141,11 @@ function CommandUserInput({
       <div className="flex flex-wrap gap-1.5 mb-2">
         {users.map((u) => (
           <span
-            key={u}
+            key={`${u.platform}:${u.name}`}
             className="inline-flex items-center gap-1 rounded-full bg-zinc-100 border border-zinc-300 px-2.5 py-0.5 text-xs text-zinc-800 dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-200"
           >
-            {u}
+            {u.platform && <PlatformTag platform={u.platform} />}
+            {u.name}
             <button
               onClick={() => onChange(users.filter((x) => x !== u))}
               className="text-zinc-500 hover:text-red-400 transition-colors leading-none"
@@ -145,6 +156,7 @@ function CommandUserInput({
         ))}
       </div>
       <div className="flex gap-1">
+        <PlatformPicker value={platform} onChange={setPicked} label={t("obsBridge.userPlatform")} />
         <input
           type="text"
           value={input}
@@ -170,7 +182,7 @@ function CommandUserInput({
 
 function ObsBridgeSetup() {
   const t = useT();
-  const [commandUsers, setCommandUsers] = useState<string[]>([]);
+  const [commandUsers, setCommandUsers] = useState<CommandUser[]>([]);
   const [obsWebsocketUrl, setObsWebsocketUrl] = useState("");
   const [obsWebsocketPassword, setObsWebsocketPassword] = useState("");
   const [twitchChannel, setTwitchChannel] = useState("");
@@ -201,7 +213,7 @@ function ObsBridgeSetup() {
     if (typeof window === "undefined") return "";
     const params = new URLSearchParams();
     if (deferredCommandUsers.length > 0) {
-      params.append("commandUser", deferredCommandUsers.join(","));
+      params.append("commandUser", formatCommandUsers(deferredCommandUsers));
     }
     if (deferredObsUrl) params.append("obsWebsocketUrl", deferredObsUrl);
     if (deferredObsPass) params.append("obsWebsocketPassword", deferredObsPass);
@@ -329,6 +341,7 @@ function ObsBridgeSetup() {
               <CommandUserInput
                 users={commandUsers}
                 onChange={setCommandUsers}
+                defaultPlatform={kickChannel.trim() && !twitchChannel.trim() ? "kick" : "twitch"}
               />
 
               {/* Custom Command Naming */}

--- a/apps/extensions/src/routes/tools/obs-bridge.tsx
+++ b/apps/extensions/src/routes/tools/obs-bridge.tsx
@@ -1,3 +1,11 @@
+import {
+  type ChatPlatform,
+  type CommandUser,
+  formatCommandUsers,
+  parseCommandUsers,
+  resolveCommandUsers,
+} from "#/features/tools/command-users";
+import { PlatformPicker, PlatformTag } from "#/features/tools/platform-picker";
 import { useChat, DEFAULT_OBS_COMMANDS, type ObsBridgeCustomCommands } from "#/features/tools/use-chat";
 import { useT } from "#/lib/i18n";
 import { getKickChannelInfo } from "#/lib/kick";
@@ -131,46 +139,89 @@ function SceneList({
 
 function CommandUsers({
   users,
-  onAdd,
-  onRemove,
+  platforms,
+  onChange,
 }: {
-  users: string[];
-  onAdd: (user: string) => void;
-  onRemove: (user: string) => void;
+  users: CommandUser[];
+  platforms: { twitch: boolean; kick: boolean };
+  onChange: (users: CommandUser[]) => void;
 }) {
   const t = useT();
   const [input, setInput] = useState("");
+  const [picked, setPicked] = useState<ChatPlatform | null>(null);
+  const bothPlatforms = platforms.twitch && platforms.kick;
+  const onlyPlatform = bothPlatforms ? null : platforms.kick ? "kick" : platforms.twitch ? "twitch" : null;
+  const platform = picked ?? onlyPlatform ?? "twitch";
+
+  const has = (p: ChatPlatform | null, name: string) =>
+    users.some((u) => u.platform === p && u.name === name);
 
   const handleAdd = () => {
     const name = input.trim().toLowerCase();
-    if (name && !users.includes(name)) {
-      onAdd(name);
+    if (name && !has(platform, name)) {
+      onChange([...users, { platform, name }]);
       setInput("");
     }
   };
+
+  const assign = (user: CommandUser, p: ChatPlatform) => {
+    onChange(
+      has(p, user.name)
+        ? users.filter((u) => u !== user)
+        : users.map((u) => (u === user ? { platform: p, name: u.name } : u)),
+    );
+  };
+
+  const unassigned = users.some((u) => !u.platform) && bothPlatforms;
 
   return (
     <div>
       <h3 className="text-sm font-semibold text-zinc-600 dark:text-zinc-400 mb-2">
         {t("tools.commandUsers", { count: users.length })}
       </h3>
+      {unassigned && (
+        <p className="mb-2 rounded-md border border-amber-300 bg-amber-50 px-2.5 py-1.5 text-xs text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300">
+          {t("tools.pickPlatformWarning")}
+        </p>
+      )}
       <div className="flex flex-wrap gap-1.5 mb-2">
-        {users.map((u) => (
-          <span
-            key={u}
-            className="inline-flex items-center gap-1 rounded-full bg-zinc-200 border border-zinc-300 px-2.5 py-0.5 text-xs text-zinc-800 dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-200"
-          >
-            {u}
-            <button
-              onClick={() => onRemove(u)}
-              className="text-zinc-500 hover:text-red-400 transition-colors leading-none"
+        {users.map((u) => {
+          const shown = u.platform ?? onlyPlatform;
+          const needsPlatform = !u.platform && bothPlatforms;
+          return (
+            <span
+              key={`${u.platform}:${u.name}`}
+              className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs ${
+                needsPlatform
+                  ? "bg-amber-50 border-amber-300 text-amber-900 dark:bg-amber-500/10 dark:border-amber-500/40 dark:text-amber-200"
+                  : "bg-zinc-200 border-zinc-300 text-zinc-800 dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-200"
+              }`}
             >
-              ✕
-            </button>
-          </span>
-        ))}
+              {shown && <PlatformTag platform={shown} />}
+              {u.name}
+              {needsPlatform &&
+                (["twitch", "kick"] as const).map((p) => (
+                  <button
+                    key={p}
+                    type="button"
+                    onClick={() => assign(u, p)}
+                    className="rounded border border-amber-300 px-1 leading-4 hover:bg-amber-100 dark:border-amber-500/40 dark:hover:bg-amber-500/20"
+                  >
+                    <PlatformTag platform={p} />
+                  </button>
+                ))}
+              <button
+                onClick={() => onChange(users.filter((x) => x !== u))}
+                className="text-zinc-500 hover:text-red-400 transition-colors leading-none"
+              >
+                ✕
+              </button>
+            </span>
+          );
+        })}
       </div>
       <div className="flex gap-1">
+        <PlatformPicker value={platform} onChange={setPicked} label={t("tools.userPlatform")} />
         <input
           type="text"
           value={input}
@@ -203,10 +254,13 @@ function RouteComponent() {
   const mainSelected = scenes.length > 0 && scenes.includes(search.mainScene);
   const brbSelected = scenes.length > 0 && scenes.includes(search.brbScene);
 
-  const commandUsers = search.commandUser ? search.commandUser
-    .split(",")
-    .map((u) => u.trim().toLowerCase())
-    .filter(Boolean) : [];
+  const commandUsers = useMemo(() => parseCommandUsers(search.commandUser), [search.commandUser]);
+  const hasTwitch = Boolean(search.twitch?.trim());
+  const hasKick = Boolean(search.kick?.trim());
+  const allowedCommandUsers = useMemo(
+    () => resolveCommandUsers(commandUsers, { twitch: hasTwitch, kick: hasKick }).allowed,
+    [commandUsers, hasTwitch, hasKick],
+  );
 
   const customCommands: ObsBridgeCustomCommands = useMemo(() => ({
     cmdBrb: search.cmdBrb || DEFAULT_OBS_COMMANDS.cmdBrb,
@@ -241,7 +295,7 @@ function RouteComponent() {
     kick,
     search.obsWebsocketUrl,
     search.obsWebsocketPassword,
-    search.commandUser,
+    allowedCommandUsers,
     onScenes,
     onConnected,
     customCommands,
@@ -263,15 +317,8 @@ function RouteComponent() {
     });
   };
 
-  const addUser = (user: string) => {
-    const updated = [...new Set([...commandUsers, user])].join(",");
-    navigate({ to: ".", search: { ...search, commandUser: updated }, replace: true });
-  };
-
-  const removeUser = (user: string) => {
-    const updated = commandUsers.filter((u) => u !== user);
-    const val = updated.length > 0 ? updated.join(",") : "";
-    navigate({ to: ".", search: { ...search, commandUser: val }, replace: true });
+  const setCommandUsers = (users: CommandUser[]) => {
+    navigate({ to: ".", search: { ...search, commandUser: formatCommandUsers(users) }, replace: true });
   };
 
   return (
@@ -322,8 +369,8 @@ function RouteComponent() {
           <div className="bg-zinc-100 p-3 rounded-md border border-zinc-200 dark:bg-zinc-800/50 dark:border-zinc-800">
             <CommandUsers
               users={commandUsers}
-              onAdd={addUser}
-              onRemove={removeUser}
+              platforms={{ twitch: hasTwitch, kick: hasKick }}
+              onChange={setCommandUsers}
             />
           </div>
 


### PR DESCRIPTION
The OBS bridge allowlist (`commandUser`) was one list of lowercased names checked against both chats. With `bob` on it, whoever registered the name `bob` on the other platform could switch scenes or `!stopstream`. Twitch and Kick names are separate namespaces, so a name alone doesn't say who someone is.

**Fix**
- Entries are saved with their platform: `commandUser=twitch:bob,kick:ali`. A chat message runs a command only when both its platform and its name match (`features/tools/command-users.ts`, check in `use-chat.ts`).
- Setup and the tool page get a Twitch/Kick picker next to the username field; chips show the platform in its color. The picker starts on the only platform set up, else Twitch. The same name can be added once per platform.

**Links saved before this** have names without a platform:
- The link sets up one platform (only `twitch` or only `kick`): the names count for that platform. Nothing changes for these streamers.
- The link sets up both: there's no telling which `bob` was meant, so these names can't run commands until a platform is picked. The tool page shows a notice, marks them in yellow, and puts Twitch / Kick buttons on each chip; one click fixes the entry and updates the URL.
- "Set up" means the `twitch` / `kick` params in the link, not whether the chat connected, so a Kick lookup failing doesn't hand an old name to Twitch.

**Behavior change:** streamers with both platforms on an old link lose command access for those names until they pick a platform on the tool page (or redo setup). That's deliberate: leaving them on both platforms would keep the hole open.

**Code**
- `features/tools/command-users.ts`: parse/format the param, `commandUserKey`, `resolveCommandUsers` (allowed keys + names that need a platform).
- `features/tools/platform-picker.tsx`: `PlatformPicker` (`aria-pressed` buttons in a labelled fieldset) and `PlatformTag`, shared by both pages.
- `use-chat.ts` takes the resolved key set instead of the raw string.
- tr/en: new `userPlatform` and `pickPlatformWarning`, updated `authorizedHint`. `llms.txt` documents the new format.

**Testing**
- `command-users.test.ts`: tagged and old names, dedupe, round trip, one platform vs both.
- `use-chat-command-users.test.ts` runs the real hook with mocked chats and OBS: a Twitch-added user's `!stopstream` reaches OBS; the same name on Kick doesn't; an old untagged name does nothing while both platforms are set up.
- Checked in Chrome (dev server): setup adds `Twitch bob` and `Kick bob` as two entries and writes `twitch:bob,kick:bob`; the tool page with an old two-platform link shows the notice and yellow chip, and picking Kick rewrites it to `kick:bob` with the notice gone; a Kick-only old link shows `Kick bob` with no notice. Light and dark, EN and TR, no console errors.
- Merges cleanly with #688 (the other `use-chat.ts` change); the merged tree passes `vitest` and `tsc`.
- `vitest` (109) and `biome lint` on the new files pass; the touched route files keep the same lint findings they had on `dev`. `tsc` shows only the known `/widgets/alerts` route tree errors on `dev`, unrelated.

**Not covered:** Twitch messages are matched by display name, which equals the login for almost everyone. A user with a localized display name (e.g. Japanese) won't match their login on the list; that's unchanged by this PR.
