### PR TITLE
fix(extensions): grow Sub Sprout when someone gifts subs on Kick

### DIFF
--- a/apps/extensions/src/features/widgets/sub-sprout/kick-sub-events.test.ts
+++ b/apps/extensions/src/features/widgets/sub-sprout/kick-sub-events.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { kickSubChannels, kickSubCount } from "./kick-sub-events";
+
+// Payloads captured from live Kick Pusher, names replaced.
+const gift = (extra: Record<string, unknown> = {}) => ({
+  chatroom_id: 1,
+  correlation_id: "110003713021787",
+  gifted_usernames: ["a", "b", "c", "d", "e"],
+  gifter_username: "Gifter",
+  gifted_total: 5,
+  gifter_total: 5,
+  chunk_details: null,
+  ...extra,
+});
+
+describe("kickSubChannels", () => {
+  it("listens where kick.com gets subs and gifted subs", () => {
+    expect(kickSubChannels("42")).toEqual(["chatrooms.42.v2", "chatroom_42"]);
+  });
+});
+
+describe("kickSubCount", () => {
+  it("counts a sub once", () => {
+    expect(
+      kickSubCount(
+        "App\\Events\\SubscriptionEvent",
+        { chatroom_id: 1, username: "Viewer", months: 1 },
+        new Set(),
+      ),
+    ).toBe(1);
+  });
+
+  it("counts every sub in a gift", () => {
+    expect(kickSubCount("GiftedSubscriptionsEvent", gift(), new Set())).toBe(5);
+  });
+
+  it("counts a gift split into chunks once, and forgets it after the last chunk", () => {
+    const seen = new Set<string>();
+    const chunk = (index: number) =>
+      gift({
+        gifted_total: 150,
+        gifted_usernames: ["a"],
+        chunk_details: { correlation_id: "c1", chunk_index: index, total_chunks: 3 },
+      });
+
+    expect(kickSubCount("GiftedSubscriptionsEvent", chunk(0), seen)).toBe(150);
+    expect(kickSubCount("GiftedSubscriptionsEvent", chunk(1), seen)).toBe(0);
+    expect(kickSubCount("GiftedSubscriptionsEvent", chunk(2), seen)).toBe(0);
+    expect(seen.size).toBe(0);
+  });
+
+  it("falls back to the gifted names when there is no total", () => {
+    expect(
+      kickSubCount("GiftedSubscriptionsEvent", gift({ gifted_total: undefined }), new Set()),
+    ).toBe(5);
+  });
+
+  it("ignores other events", () => {
+    for (const event of ["App\\Events\\ChatMessageEvent", "RewardRedeemedEvent", "KicksGifted"]) {
+      expect(kickSubCount(event, gift(), new Set())).toBe(0);
+    }
+  });
+});

--- a/apps/extensions/src/features/widgets/sub-sprout/kick-sub-events.ts
+++ b/apps/extensions/src/features/widgets/sub-sprout/kick-sub-events.ts
@@ -1,0 +1,62 @@
+// Pusher channels kick.com's own chat listens on: subs and chat on chatrooms.{id}.v2, gifted subs
+// on chatroom_{id}. Both take the chatroom id, not the channel id.
+export const kickSubChannels = (chatroomId: string): string[] => [
+  `chatrooms.${chatroomId}.v2`,
+  `chatroom_${chatroomId}`,
+];
+
+type GiftedSubscriptions = {
+  gifted_usernames?: unknown;
+  gifted_total?: unknown;
+  chunk_details?: {
+    correlation_id?: unknown;
+    chunk_index?: unknown;
+    total_chunks?: unknown;
+  } | null;
+};
+
+/**
+ * How many subs a Kick event adds, 0 when it isn't a sub. A large gift arrives in several
+ * GiftedSubscriptionsEvent chunks that share a correlation_id and all carry the gift's
+ * gifted_total, so only the first chunk counts. seenGifts keeps the ids of gifts in flight.
+ */
+export function kickSubCount(
+  eventName: string,
+  payload: Record<string, unknown> | null,
+  seenGifts: Set<string>,
+): number {
+  if (eventName === "App\\Events\\SubscriptionEvent") {
+    return 1;
+  }
+  if (eventName !== "GiftedSubscriptionsEvent" || !payload) {
+    return 0;
+  }
+
+  const gift = payload as GiftedSubscriptions;
+  const chunk = gift.chunk_details;
+  const correlationId =
+    typeof chunk?.correlation_id === "string" ? chunk.correlation_id : null;
+  const firstChunk = !correlationId || !seenGifts.has(correlationId);
+  if (correlationId) {
+    const last =
+      typeof chunk?.chunk_index === "number" &&
+      typeof chunk.total_chunks === "number" &&
+      chunk.chunk_index >= chunk.total_chunks - 1;
+    if (last) {
+      seenGifts.delete(correlationId);
+    } else {
+      seenGifts.add(correlationId);
+    }
+  }
+  if (!firstChunk) {
+    return 0;
+  }
+
+  const total = typeof gift.gifted_total === "number" ? gift.gifted_total : NaN;
+  if (Number.isFinite(total) && total > 0) {
+    return Math.floor(total);
+  }
+  return Array.isArray(gift.gifted_usernames) && gift.gifted_usernames.length > 0
+    ? gift.gifted_usernames.length
+    : 1;
+}

--- a/apps/extensions/src/features/widgets/sub-sprout/sub-sprout-kick.test.tsx
+++ b/apps/extensions/src/features/widgets/sub-sprout/sub-sprout-kick.test.tsx
@@ -1,0 +1,79 @@
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SubSproutWidget } from "./sub-sprout-widget";
+
+class FakeWebSocket {
+  static last: FakeWebSocket;
+  sent: string[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  constructor() {
+    FakeWebSocket.last = this;
+  }
+  send(data: string) {
+    this.sent.push(data);
+  }
+  close() {}
+}
+
+const pusher = (channel: string, event: string, data: unknown) =>
+  act(() => {
+    FakeWebSocket.last.onmessage?.({
+      data: JSON.stringify({ event, channel, data: JSON.stringify(data) }),
+    });
+  });
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal("WebSocket", FakeWebSocket);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("SubSproutWidget on Kick", () => {
+  it("subscribes to the chatroom channels Kick sends subs and gifts on", () => {
+    render(<SubSproutWidget kickChannel="streamer" kickId="42" variety="rose" />);
+    act(() => FakeWebSocket.last.onopen?.());
+    const channels = FakeWebSocket.last.sent.map((s) => JSON.parse(s).data.channel);
+    expect(channels).toEqual(["chatrooms.42.v2", "chatroom_42"]);
+  });
+
+  it("grows one stage per gifted sub", () => {
+    const { container } = render(
+      <SubSproutWidget
+        kickChannel="streamer"
+        kickId="42"
+        variety="rose"
+        potLabel
+        countFx={false}
+      />,
+    );
+    act(() => FakeWebSocket.last.onopen?.());
+
+    // Payload captured from live Kick, names replaced.
+    pusher("chatroom_42", "GiftedSubscriptionsEvent", {
+      chatroom_id: 42,
+      correlation_id: "110003713021787",
+      gifted_usernames: ["a", "b", "c", "d", "e"],
+      gifter_username: "Gifter",
+      gifted_total: 5,
+      gifter_total: 5,
+      chunk_details: null,
+    });
+    act(() => vi.advanceTimersByTime(5 * 800));
+    expect(container.textContent).toContain("5/10");
+
+    pusher("chatrooms.42.v2", "App\\Events\\SubscriptionEvent", {
+      chatroom_id: 42,
+      username: "Viewer",
+      months: 1,
+    });
+    act(() => vi.advanceTimersByTime(800));
+    expect(container.textContent).toContain("6/10");
+  });
+});

--- a/apps/extensions/src/features/widgets/sub-sprout/sub-sprout-widget.tsx
+++ b/apps/extensions/src/features/widgets/sub-sprout/sub-sprout-widget.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { kickSubChannels, kickSubCount } from "./kick-sub-events";
 import { PlantSlot } from "./plant-slot";
 import { SubCountFX, SUB_COUNT_DURATION_MS } from "./fx/sub-count-fx";
 import { VineOverlay } from "./plants/vine-overlay";
@@ -22,7 +23,6 @@ export interface SubSproutWidgetProps {
   twitchChannel?: string;
   kickChannel?: string;
   kickId?: string;
-  kickChannelId?: string;
   variety?: PlantId | string;
   pick?: PickMode | string;
   water?: WaterEffectType | string;
@@ -105,7 +105,6 @@ export function SubSproutWidget({
   twitchChannel,
   kickChannel,
   kickId,
-  kickChannelId,
   variety = "classic",
   pick = "fixed",
   water = "off",
@@ -143,9 +142,6 @@ export function SubSproutWidget({
   const pendingAnonGiftSlots = useRef<{ count: number; at: number } | null>(
     null,
   );
-  const pendingKickGiftSlots = useRef<{ count: number; at: number } | null>(
-    null,
-  );
   const [activeWaterSlot, setActiveWaterSlot] = useState<{
     slot: number;
     key: number;
@@ -161,35 +157,28 @@ export function SubSproutWidget({
   const syncJoined = () =>
     setJoined(twitchConnectedRef.current || kickConnectedRef.current);
 
-  const [clientKickIds, setClientKickIds] = useState<{
-    kickId: string | null;
-    kickChannelId: string | null;
-  }>({ kickId: null, kickChannelId: null });
+  const [clientKickId, setClientKickId] = useState<string | null>(null);
 
-  const effectiveKickId = kickId ?? clientKickIds.kickId;
-  const effectiveKickChannelId = kickChannelId ?? clientKickIds.kickChannelId;
+  const effectiveKickId = kickId ?? clientKickId;
 
   useEffect(() => {
     if (simulate === true) return;
-    if ((kickId && kickChannelId) || !kickChannel) return;
+    if (kickId || !kickChannel) return;
     let cancelled = false;
     fetch(
       `https://kick.com/api/v1/channels/${encodeURIComponent(kickChannel)}`,
       { headers: { Accept: "application/json" } },
     )
       .then(r => (r.ok ? r.json() : Promise.reject(new Error("Kick channel lookup failed"))))
-      .then((data: { id?: unknown; chatroom?: { id?: unknown } }) => {
+      .then((data: { chatroom?: { id?: unknown } }) => {
         if (cancelled) return;
-        setClientKickIds({
-          kickId: data.chatroom?.id == null ? null : String(data.chatroom.id),
-          kickChannelId: data.id == null ? null : String(data.id),
-        });
+        setClientKickId(data.chatroom?.id == null ? null : String(data.chatroom.id));
       })
       .catch(() => {});
     return () => {
       cancelled = true;
     };
-  }, [kickChannel, kickId, kickChannelId, simulate]);
+  }, [kickChannel, kickId, simulate]);
 
   const applyGrowth = useCallback(() => {
     const { targetSlot, perSlot } = distributeGrowth(
@@ -414,7 +403,8 @@ export function SubSproutWidget({
     };
 
     const loadKick = () => {
-      if (!effectiveKickId && !effectiveKickChannelId) return;
+      if (!effectiveKickId) return;
+      const chatroomId = effectiveKickId;
 
       const MAX_RECONNECT_DELAY_MS = 30000;
       let ws: WebSocket | null = null;
@@ -446,20 +436,7 @@ export function SubSproutWidget({
         socket.onopen = () => {
           console.log("[Kick] WebSocket connected");
           reconnectAttempts = 0;
-        const channelNames = new Set<string>();
-
-        if (effectiveKickId) {
-          channelNames.add(`chatrooms.${effectiveKickId}.v2`);
-          channelNames.add(`chatrooms.${effectiveKickId}`);
-        }
-
-        if (effectiveKickChannelId) {
-          channelNames.add(`channel.${effectiveKickChannelId}`);
-          channelNames.add(`channel.${effectiveKickChannelId}.v2`);
-          channelNames.add(`chatrooms.${effectiveKickChannelId}.v2`);
-        }
-
-        for (const channelName of channelNames) {
+        for (const channelName of kickSubChannels(chatroomId)) {
           socket.send(
             JSON.stringify({
               event: "pusher:subscribe",
@@ -470,6 +447,7 @@ export function SubSproutWidget({
         }
       };
 
+      const seenGifts = new Set<string>();
       const recentEvents: { key: string; at: number }[] = [];
       const isDuplicate = (key: string): boolean => {
         const now = Date.now();
@@ -511,44 +489,6 @@ export function SubSproutWidget({
               ? (data as Record<string, unknown>)
               : null;
           };
-          const pickAmount = (payload: Record<string, unknown> | null) => {
-            if (!payload) return NaN;
-
-            const candidates: unknown[] = [
-              payload.gifted_subscriptions_count,
-              payload.subscriptions_count,
-              payload.quantity,
-              payload.count,
-              payload.amount,
-            ];
-
-            const nestedData = payload.data;
-            if (nestedData && typeof nestedData === "object") {
-              const nested = nestedData as Record<string, unknown>;
-              candidates.push(
-                nested.gifted_subscriptions_count,
-                nested.subscriptions_count,
-                nested.quantity,
-                nested.count,
-                nested.amount,
-              );
-            }
-
-            for (const value of candidates) {
-              const asNumber =
-                typeof value === "number"
-                  ? value
-                  : typeof value === "string"
-                    ? Number(value)
-                    : NaN;
-              if (Number.isFinite(asNumber) && asNumber > 0) {
-                return asNumber;
-              }
-            }
-
-            return NaN;
-          };
-
           if (eventName === "pusher:ping") {
             socket.send(JSON.stringify({ event: "pusher:pong" }));
             return;
@@ -561,12 +501,9 @@ export function SubSproutWidget({
             return;
           }
 
-          const isGiftPurchaseEvent = eventName.includes("GiftSubPurchase");
-          const isGiftRedeemEvent = eventName.includes("GiftSubRedeemed");
           const isSubOrGiftEvent =
-            eventName.includes("Subscription") ||
-            eventName.includes("Subscribed") ||
-            (eventName.includes("Gift") && eventName.includes("Event"));
+            eventName === "App\\Events\\SubscriptionEvent" ||
+            eventName === "GiftedSubscriptionsEvent";
           const isChatMessageEvent =
             eventName === "App\\Events\\ChatMessageEvent";
 
@@ -581,25 +518,10 @@ export function SubSproutWidget({
 
           if (isSubOrGiftEvent) {
             const payload = parsePayload(response.data);
-            const numericAmount = pickAmount(payload);
-            const amount =
-              Number.isFinite(numericAmount) && numericAmount > 0
-                ? Math.floor(numericAmount)
-                : 1;
             console.debug("[SubSprout] Kick sub/gift event:", eventName, payload);
-
-            if (isGiftRedeemEvent) {
-              // Redemption belonging to a recently announced gift bundle must
-              // not grow the plant a second time.
-              if (!consumeBundleSlot(pendingKickGiftSlots)) {
-                handleSubEvent(1);
-              }
-            } else if (isGiftPurchaseEvent) {
-              pendingKickGiftSlots.current = { count: amount, at: Date.now() };
-              handleSubEvent(amount);
-            } else {
-              // SubscriptionEvent covers both new subs and resubs.
-              handleSubEvent(amount);
+            const count = kickSubCount(eventName, payload, seenGifts);
+            if (count > 0) {
+              handleSubEvent(count);
             }
             return;
           }
@@ -676,7 +598,7 @@ export function SubSproutWidget({
       });
     }
 
-    if (kickChannel && (effectiveKickId || effectiveKickChannelId)) {
+    if (kickChannel && effectiveKickId) {
       const kickCleanup = loadKick();
       if (kickCleanup) cleanups.push(kickCleanup);
     }
@@ -684,7 +606,7 @@ export function SubSproutWidget({
     return () => {
       for (const cleanup of cleanups) cleanup();
     };
-  }, [twitchChannel, kickChannel, effectiveKickId, effectiveKickChannelId, handleSubEvent]);
+  }, [twitchChannel, kickChannel, effectiveKickId, handleSubEvent]);
 
   useEffect(() => {
     if (!activeWaterSlot) return;

--- a/apps/extensions/src/routes/widgets/sub-sprout-widget.tsx
+++ b/apps/extensions/src/routes/widgets/sub-sprout-widget.tsx
@@ -66,15 +66,12 @@ export const Route = createFileRoute("/widgets/sub-sprout-widget")({
       try {
         const { getKickChannelInfo } = await import("#/lib/kick");
         const kickInfo = await getKickChannelInfo(deps.kickChannel);
-        return {
-          kickId: kickInfo.chatroomId,
-          kickChannelId: kickInfo.channelId,
-        };
+        return { kickId: kickInfo.chatroomId };
       } catch {
-        return { kickId: null, kickChannelId: null };
+        return { kickId: null };
       }
     }
-    return { kickId: null, kickChannelId: null };
+    return { kickId: null };
   },
   component: RouteComponent,
 });
@@ -92,7 +89,7 @@ function RouteComponent() {
     potlabel,
     simulate,
   } = Route.useSearch();
-  const { kickId, kickChannelId } = Route.useLoaderData();
+  const { kickId } = Route.useLoaderData();
 
   const twitchChannel =
     twitch || (platform === "twitch" ? channel : undefined);
@@ -109,7 +106,6 @@ function RouteComponent() {
         twitchChannel={twitchChannel}
         kickChannel={kickChannel}
         kickId={kickId ?? undefined}
-        kickChannelId={kickChannelId ?? undefined}
         variety={variety}
         pick={pick}
         water={water}


### PR DESCRIPTION
On Kick, gifting subs didn't grow the Sub Sprout plant at all.

**Why**
- Kick sends gifted subs as `GiftedSubscriptionsEvent` (no `App\Events\` prefix) on the Pusher channel `chatroom_{chatroomId}`. That's where kick.com's own chat listens for them (checked in its current JS bundle). Sub Sprout subscribed to `chatrooms.{id}.v2`, `chatrooms.{id}`, `channel.{channelId}`, `channel.{channelId}.v2` and `chatrooms.{channelId}.v2`, never `chatroom_{id}`, so gift events never reached it.
- The gift handler waited for `GiftSubPurchase` / `GiftSubRedeemed`, names Kick doesn't send (they aren't in kick.com's bundle either).
- Even a delivered gift would have grown 1 stage: the amount was read from `gifted_subscriptions_count`, `quantity`, `count`…, while Kick's payload has `gifted_total`.

Live capture from 20 busy Kick channels (two runs, 17 min): 5 `GiftedSubscriptionsEvent`, all on `chatroom_{id}`, none on the channels the widget used. `SubscriptionEvent` comes on `chatrooms.{id}.v2`, which the widget did get, so plain subs already worked.

A captured gift, names removed:
```json
{"chatroom_id":15423903,"correlation_id":"110003713021787","gifted_usernames":["…5 names"],"gifter_username":"…","gifted_total":5,"gifter_total":5,"chunk_details":null}
```

**Fix**
- `features/widgets/sub-sprout/kick-sub-events.ts`: `kickSubChannels(chatroomId)` = `chatrooms.{id}.v2` + `chatroom_{id}`; `kickSubCount` maps an event to a sub count: `SubscriptionEvent` → 1, `GiftedSubscriptionsEvent` → `gifted_total` (falls back to the number of names). A large gift arrives in chunks that share `chunk_details.correlation_id` and all carry the full total (that's how kick.com's own overlay reads them), so only the first chunk counts.
- The widget matches event names exactly instead of by substring (`includes("Subscription")`, `includes("Gift")`), which is what let the wrong names slip through.
- The channel-id subscriptions carried none of these events in the capture, so they're dropped, along with the now unused `kickChannelId` prop and loader field.

**Not counted, on purpose:** `celebration` chat messages (`subscription_renewed`). They are a viewer sharing a renewal days later (their `created_at` is days old); the renewal itself already arrives as `SubscriptionEvent` (captured one with `months: 20`), so counting both would grow twice.

**Testing**
- `kick-sub-events.test.ts`: sub, 5-sub gift, a 150-sub gift in 3 chunks counts once and is forgotten after the last chunk, fallback to names, other events ignored.
- `sub-sprout-kick.test.tsx` renders the widget over a fake WebSocket: it subscribes to exactly `chatrooms.42.v2` and `chatroom_42`; the captured 5-gift payload takes the pot label from 0 to `5/10`, a sub to `6/10`. On the old code both fail: it subscribed to `chatrooms.42` instead of `chatroom_42`, and the gift grew to `1/10`.
- Chunked gifts didn't show up in the capture; that path follows kick.com's own handling.
- `vitest` (107) and `biome lint` on the new files pass; the widget file keeps the lint findings it had on `dev`. `tsc` shows only the known `/widgets/alerts` route tree errors on `dev`, unrelated.
