### PR TITLE
fix(extensions): stop emote wall setup from writing bogus URL params

### DIFF
--- a/apps/extensions/src/features/widgets/emote-wall/widget-url.test.ts
+++ b/apps/extensions/src/features/widgets/emote-wall/widget-url.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { buildEmoteWallParams, buildEmoteWallUrl, type EmoteWallUrlOptions } from './widget-url';
+
+const ORIGIN = 'https://extensions.senchabot.com';
+
+const defaults: EmoteWallUrlOptions = {
+  twitch: '',
+  kick: '',
+  platforms: 'both',
+  sevenTv: true,
+  mode: 'calm',
+  subsOnly: false,
+  subDurationX2: false,
+  showAllEmotes: false,
+  hypeMode: false,
+  spamBlock: true,
+  size: '112',
+  duration: '5',
+  max: '25',
+};
+
+const url = (overrides: Partial<EmoteWallUrlOptions>) =>
+  buildEmoteWallUrl(ORIGIN, { ...defaults, twitch: 'Sencha', ...overrides });
+
+describe('buildEmoteWallUrl', () => {
+  it('omits every param that equals the widget default', () => {
+    expect(url({})).toBe(`${ORIGIN}/widgets/emote-wall?twitch=sencha`);
+  });
+
+  it.each([
+    ['size', 'size'],
+    ['duration', 'duration'],
+    ['max', 'max'],
+  ] as const)('omits %s when its field is empty', (field, param) => {
+    expect(new URL(url({ [field]: '' })).searchParams.has(param)).toBe(false);
+    expect(new URL(url({ [field]: '   ' })).searchParams.has(param)).toBe(false);
+  });
+
+  it('omits numeric params that are not numbers', () => {
+    const params = new URL(url({ size: 'abc', duration: '-', max: 'NaN' })).searchParams;
+    expect(params.has('size')).toBe(false);
+    expect(params.has('duration')).toBe(false);
+    expect(params.has('max')).toBe(false);
+  });
+
+  it('clamps out-of-range numbers into the widget range', () => {
+    const low = new URL(url({ size: '8', duration: '0', max: '0' })).searchParams;
+    expect(low.get('size')).toBe('32');
+    expect(low.get('duration')).toBe('2');
+    expect(low.get('max')).toBe('1');
+
+    const high = new URL(url({ size: '999', duration: '99', max: '500' })).searchParams;
+    expect(high.get('size')).toBe('256');
+    expect(high.get('duration')).toBe('30');
+    expect(high.get('max')).toBe('120');
+  });
+
+  it('keeps the existing param contract for non-default values', () => {
+    expect(
+      url({
+        kick: ' SomeKick ',
+        sevenTv: false,
+        mode: 'bounce',
+        subsOnly: true,
+        subDurationX2: true,
+        showAllEmotes: true,
+        hypeMode: true,
+        spamBlock: false,
+        size: '160',
+        duration: '12',
+        max: '40',
+      }),
+    ).toBe(
+      `${ORIGIN}/widgets/emote-wall?twitch=sencha&kick=somekick&sevenTv=false&mode=bounce` +
+        '&subsOnly=true&subDurationX2=true&showAllEmotes=true&hypeMode=true&spamBlock=false' +
+        '&size=160&duration=12&max=40',
+    );
+  });
+
+  it('is empty when no channel is filled in', () => {
+    expect(url({ twitch: '', kick: '' })).toBe('');
+    expect(url({ twitch: '   ' })).toBe('');
+  });
+
+  it('is empty when the only channel belongs to an unselected platform', () => {
+    expect(url({ platforms: 'kick', twitch: 'sencha', kick: '' })).toBe('');
+    expect(url({ platforms: 'twitch', twitch: '', kick: 'sencha' })).toBe('');
+  });
+
+  it('drops the unselected platform channel but keeps the selected one', () => {
+    expect(url({ platforms: 'kick', twitch: 'sencha', kick: 'kicker' })).toBe(
+      `${ORIGIN}/widgets/emote-wall?kick=kicker`,
+    );
+    expect(url({ platforms: 'twitch', twitch: 'sencha', kick: 'kicker' })).toBe(
+      `${ORIGIN}/widgets/emote-wall?twitch=sencha`,
+    );
+  });
+});
+
+describe('buildEmoteWallParams', () => {
+  it('builds params without a channel for the mock preview', () => {
+    expect(buildEmoteWallParams({ ...defaults, duration: '' }).toString()).toBe('');
+  });
+});

--- a/apps/extensions/src/features/widgets/emote-wall/widget-url.ts
+++ b/apps/extensions/src/features/widgets/emote-wall/widget-url.ts
@@ -1,0 +1,56 @@
+export type EmoteWallPlatforms = 'both' | 'twitch' | 'kick';
+export type EmoteWallMode = 'calm' | 'chaos' | 'bounce';
+
+export interface EmoteWallUrlOptions {
+  twitch: string;
+  kick: string;
+  platforms: EmoteWallPlatforms;
+  sevenTv: boolean;
+  mode: EmoteWallMode;
+  subsOnly: boolean;
+  subDurationX2: boolean;
+  showAllEmotes: boolean;
+  hypeMode: boolean;
+  spamBlock: boolean;
+  /** Raw input values; empty or non-numeric means "use the widget default". */
+  size: string;
+  duration: string;
+  max: string;
+}
+
+// Ranges and defaults mirror the widget's searchSchema (routes/widgets/emote-wall.tsx),
+// so an omitted param and a default-valued one render the same widget.
+const clampParam = (raw: string, min: number, max: number, fallback: number) => {
+  const n = raw.trim() === '' ? Number.NaN : Number(raw);
+  if (!Number.isFinite(n)) return String(fallback);
+  return String(Math.min(max, Math.max(min, n)));
+};
+
+export function buildEmoteWallParams(options: EmoteWallUrlOptions): URLSearchParams {
+  const params = new URLSearchParams();
+  const twitch = options.twitch.trim().toLowerCase();
+  const kick = options.kick.trim().toLowerCase();
+  if (options.platforms !== 'kick' && twitch) params.append('twitch', twitch);
+  if (options.platforms !== 'twitch' && kick) params.append('kick', kick);
+  if (!options.sevenTv) params.append('sevenTv', 'false');
+  if (options.mode !== 'calm') params.append('mode', options.mode);
+  if (options.subsOnly) params.append('subsOnly', 'true');
+  if (options.subDurationX2) params.append('subDurationX2', 'true');
+  if (options.showAllEmotes) params.append('showAllEmotes', 'true');
+  if (options.hypeMode) params.append('hypeMode', 'true');
+  if (!options.spamBlock) params.append('spamBlock', 'false');
+  const size = clampParam(options.size, 32, 256, 112);
+  if (size !== '112') params.append('size', size);
+  const duration = clampParam(options.duration, 2, 30, 5);
+  if (duration !== '5') params.append('duration', duration);
+  const max = clampParam(options.max, 1, 120, 25);
+  if (max !== '25') params.append('max', max);
+  return params;
+}
+
+/** Empty unless the URL names a channel on a selected platform. */
+export function buildEmoteWallUrl(origin: string, options: EmoteWallUrlOptions): string {
+  const params = buildEmoteWallParams(options);
+  if (!params.has('twitch') && !params.has('kick')) return '';
+  return `${origin}/widgets/emote-wall?${params.toString()}`;
+}

--- a/apps/extensions/src/routes/setup/emote-wall.tsx
+++ b/apps/extensions/src/routes/setup/emote-wall.tsx
@@ -1,5 +1,10 @@
 import { Breadcrumb } from '#/components/breadcrumb';
 import { YoutubeTutorial } from '#/components/youtube-tutorial';
+import {
+  buildEmoteWallParams,
+  buildEmoteWallUrl,
+  type EmoteWallUrlOptions,
+} from '#/features/widgets/emote-wall/widget-url';
 import { useI18n } from '#/lib/i18n';
 import { getLocaleLinks } from '#/lib/i18n/seo';
 import { createFileRoute, Link } from '@tanstack/react-router';
@@ -132,56 +137,34 @@ function EmoteWallSetup() {
   const deferredTwitch = useDeferredValue(twitchChannel);
   const deferredKick = useDeferredValue(kickChannel);
 
-  // Number inputs accept out-of-range typing, so clamp before writing params.
-  const clampParam = (raw: string, min: number, max: number, fallback: number) => {
-    const n = Number(raw);
-    if (!Number.isFinite(n)) return String(fallback);
-    return String(Math.min(max, Math.max(min, n)));
-  };
+  const urlOptions = (twitch: string, kick: string): EmoteWallUrlOptions => ({
+    twitch,
+    kick,
+    platforms,
+    sevenTv,
+    mode,
+    subsOnly,
+    subDurationX2,
+    showAllEmotes,
+    hypeMode,
+    spamBlock,
+    size: emoteSize,
+    duration,
+    max: maxEmotes,
+  });
 
-  const buildParams = (
-    twitch: string,
-    kick: string,
-    withMock: boolean,
-  ) => {
-    const params = new URLSearchParams();
-    if (platforms === 'both' || platforms === 'twitch') {
-      if (twitch.trim())
-        params.append('twitch', twitch.trim().toLowerCase());
-    }
-    if (platforms === 'both' || platforms === 'kick') {
-      if (kick.trim()) params.append('kick', kick.trim().toLowerCase());
-    }
-    if (!sevenTv) params.append('sevenTv', 'false');
-    if (mode !== 'calm') params.append('mode', mode);
-    if (subsOnly) params.append('subsOnly', 'true');
-    if (subDurationX2) params.append('subDurationX2', 'true');
-    if (showAllEmotes) params.append('showAllEmotes', 'true');
-    if (hypeMode) params.append('hypeMode', 'true');
-    if (!spamBlock) params.append('spamBlock', 'false');
-    if (emoteSize !== '112') params.append('size', clampParam(emoteSize, 32, 256, 112));
-    const safeDuration = clampParam(duration, 2, 30, 5);
-    if (safeDuration !== '5') params.append('duration', safeDuration);
-    const safeMax = clampParam(maxEmotes, 1, 120, 25);
-    if (safeMax !== '25') params.append('max', safeMax);
-    if (withMock) {
-      params.append('mock', 'true');
-      params.append('lang', locale);
-    }
-    return params;
-  };
-
+  // Gated on mount so the prerendered input and the first client render agree.
   const widgetUrl = useMemo(() => {
-    if (typeof window === 'undefined') return '';
-    const params = buildParams(twitchChannel, kickChannel, false);
-    if (!twitchChannel.trim() && !kickChannel.trim()) return '';
-    return `${window.location.origin}/widgets/emote-wall?${params.toString()}`;
+    if (!mounted) return '';
+    return buildEmoteWallUrl(window.location.origin, urlOptions(twitchChannel, kickChannel));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [twitchChannel, kickChannel, platforms, sevenTv, mode, subsOnly, subDurationX2, showAllEmotes, hypeMode, spamBlock, emoteSize, duration, maxEmotes]);
+  }, [mounted, twitchChannel, kickChannel, platforms, sevenTv, mode, subsOnly, subDurationX2, showAllEmotes, hypeMode, spamBlock, emoteSize, duration, maxEmotes]);
 
   const previewUrl = useMemo(() => {
     if (typeof window === 'undefined') return '';
-    const params = buildParams(deferredTwitch, deferredKick, true);
+    const params = buildEmoteWallParams(urlOptions(deferredTwitch, deferredKick));
+    params.append('mock', 'true');
+    params.append('lang', locale);
     return `${window.location.origin}/widgets/emote-wall?${params.toString()}`;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
@@ -208,10 +191,6 @@ function EmoteWallSetup() {
       setTimeout(() => setCopied(false), 2000);
     }
   };
-
-  const isFormValid =
-    (platforms !== 'kick' && twitchChannel.trim().length > 0) ||
-    (platforms !== 'twitch' && kickChannel.trim().length > 0);
 
   return (
     <div className="min-h-screen bg-zinc-50 text-zinc-900 font-sans p-6 pt-12 dark:bg-zinc-950 dark:text-zinc-100">
@@ -478,7 +457,7 @@ function EmoteWallSetup() {
                   />
                   <button
                     onClick={handleCopy}
-                    disabled={!isFormValid}
+                    disabled={!widgetUrl}
                     className="rounded-r-md bg-green-600 px-4 py-2 font-medium text-white hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                   >
                     {copied ? t('common.copied') : t('common.copy')}
@@ -524,7 +503,7 @@ function EmoteWallSetup() {
                   />
                   <button
                     onClick={handleCopy}
-                    disabled={!isFormValid}
+                    disabled={!widgetUrl}
                     className="rounded-r-md bg-green-600 px-4 py-2 font-medium text-white hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                   >
                     {copied ? t('common.copied') : t('common.copy')}


### PR DESCRIPTION
Fixes three URL-building bugs on the Emote Wall setup page. Existing OBS URLs keep working: param names, values and encodings are unchanged for every non-empty input.

**What was broken**
- Emptying Duration or Max wrote `duration=2` / `max=1` into the widget URL, because `Number('')` is `0` and the clamp raised it to the minimum.
- With Platforms set to Kick only and text left in the Twitch field (or the reverse), the URL field showed a URL with no channel. Copy was disabled, but the field was misleading.
- The widget URL was guarded with `typeof window`, so the prerendered input could differ from the first client render.

**What changed**
- URL building moved into a pure module, `features/widgets/emote-wall/widget-url.ts`.
- An empty or non-numeric size, duration or max falls back to the widget default and the param is left out, matching the widget's search schema.
- The URL is empty unless it has a channel for a selected platform. The Copy buttons use that same URL instead of a separate validity check that had drifted from it.
- The widget URL waits for the `mounted` flag the preview already uses.

**Testing**
- New unit tests in `widget-url.test.ts`: empty/non-numeric fields left out, out-of-range values clamped, defaults left out, platform/channel mismatch gives an empty URL, and a full URL check that the param format is unchanged.
- `vitest run`: 110/110 passing.
- `tsc --noEmit`: no new errors (only the known, unrelated `/widgets/alerts` route-tree errors).
- `biome lint`: no new errors.
