### PR TITLE
fix(extensions): fix raffle entry eligibility and setup inputs

### DIFF
--- a/apps/extensions/src/features/widgets/raffle/raffle-widget.tsx
+++ b/apps/extensions/src/features/widgets/raffle/raffle-widget.tsx
@@ -357,7 +357,11 @@ export function RaffleWidget({
                         : "bg-[#53FC18] text-black hover:bg-[#45D115]"
                     }`}
                     onClick={start}
-                    disabled={isRunning || !state.config.channel.trim()}>
+                    disabled={
+                      isRunning ||
+                      !state.config.channel.trim() ||
+                      !state.config.keyword.trim()
+                    }>
                     {t("raffle.startRaffle")}
                   </button>
                   <button

--- a/apps/extensions/src/features/widgets/raffle/raffle-widget.tsx
+++ b/apps/extensions/src/features/widgets/raffle/raffle-widget.tsx
@@ -61,6 +61,8 @@ export function RaffleWidget({
 
   const [lastWinner, setLastWinner] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  // Raw text while the field is focused, so clearing it doesn't snap back to 1 mid-edit.
+  const [minSubMonthsDraft, setMinSubMonthsDraft] = useState<string | null>(null);
   const confettiRafRef = useRef<number | null>(null);
   const [now, setNow] = useState(() => Date.now());
 
@@ -270,15 +272,17 @@ export function RaffleWidget({
                     type="number"
                     min={1}
                     className="w-full rounded-md border border-zinc-300 bg-zinc-100 px-3 py-2 text-zinc-900 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white disabled:cursor-not-allowed disabled:opacity-60 focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500"
-                    value={state.config.minSubMonths}
-                    onChange={(e) =>
+                    value={minSubMonthsDraft ?? state.config.minSubMonths}
+                    onChange={(e) => {
+                      setMinSubMonthsDraft(e.target.value);
                       updateConfig({
                         minSubMonths: Math.max(
                           1,
-                          parseInt(e.target.value || "1", 10),
+                          parseInt(e.target.value, 10) || 1,
                         ),
-                      })
-                    }
+                      });
+                    }}
+                    onBlur={() => setMinSubMonthsDraft(null)}
                     disabled={isConfigLocked}
                   />
                   <p className="mt-1 text-xs text-zinc-500">

--- a/apps/extensions/src/hooks/use-raffle-chat.test.ts
+++ b/apps/extensions/src/hooks/use-raffle-chat.test.ts
@@ -117,16 +117,16 @@ describe('shouldAcceptEntry', () => {
     ).toBe(false);
   });
 
-  it('rejects subscribers with too few months when minSubMonths > 0', () => {
+  it('rejects subscribers with too few months when subscribersOnly is true', () => {
     expect(
       shouldAcceptEntry(true, 0, {
-        subscribersOnly: false,
+        subscribersOnly: true,
         minSubMonths: 3,
       }),
     ).toBe(false);
     expect(
       shouldAcceptEntry(true, 2, {
-        subscribersOnly: false,
+        subscribersOnly: true,
         minSubMonths: 3,
       }),
     ).toBe(false);
@@ -135,16 +135,57 @@ describe('shouldAcceptEntry', () => {
   it('accepts subscribers at or above the minSubMonths threshold', () => {
     expect(
       shouldAcceptEntry(true, 3, {
-        subscribersOnly: false,
+        subscribersOnly: true,
         minSubMonths: 3,
       }),
     ).toBe(true);
     expect(
       shouldAcceptEntry(true, 12, {
+        subscribersOnly: true,
+        minSubMonths: 3,
+      }),
+    ).toBe(true);
+  });
+
+  it('ignores minSubMonths when subscribersOnly is false', () => {
+    // Regression: the hidden min-months field (default 1) still filtered
+    // subscribers and kept a broadcaster without a sub badge (-1) out.
+    expect(
+      shouldAcceptEntry(true, 2, {
         subscribersOnly: false,
         minSubMonths: 3,
       }),
     ).toBe(true);
+    expect(
+      shouldAcceptEntry(true, -1, {
+        subscribersOnly: false,
+        minSubMonths: 1,
+      }),
+    ).toBe(true);
+  });
+
+  it('treats the 1-month floor as any subscriber, including the broadcaster', () => {
+    expect(
+      shouldAcceptEntry(true, 0, {
+        subscribersOnly: true,
+        minSubMonths: 1,
+      }),
+    ).toBe(true);
+    expect(
+      shouldAcceptEntry(true, -1, {
+        subscribersOnly: true,
+        minSubMonths: 1,
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects the broadcaster when subscribersOnly requires more than 1 month', () => {
+    expect(
+      shouldAcceptEntry(true, -1, {
+        subscribersOnly: true,
+        minSubMonths: 3,
+      }),
+    ).toBe(false);
   });
 
   it('accepts everyone when minSubMonths is 0 and subscribersOnly is false', () => {

--- a/apps/extensions/src/hooks/use-raffle-chat.ts
+++ b/apps/extensions/src/hooks/use-raffle-chat.ts
@@ -89,7 +89,9 @@ export function shouldAcceptEntry(
   config: Pick<RaffleConfig, "subscribersOnly" | "minSubMonths">,
 ): boolean {
   if (config.subscribersOnly && !isSub) return false;
-  if (isSub && config.minSubMonths > 0) {
+  // The 1-month floor means "any subscriber", so a badge without tenure (0) and the broadcaster
+  // (-1, can't sub to their own channel) still get in; only a higher minimum checks months.
+  if (config.subscribersOnly && config.minSubMonths > 1) {
     const effectiveMonths = subMonths >= 0 ? subMonths : 0;
     if (effectiveMonths < config.minSubMonths) {
       return false;


### PR DESCRIPTION
Fixes three raffle setup bugs that let a raffle reject valid entrants or accept a config nobody can enter.

**Subscriber rules**
- The min sub months check ran even with "Subscribers only" off. The field is hidden then, but its value (default 1) still rejected subscribers below it, and a broadcaster without a sub badge couldn't enter their own raffle.
- Min months now applies only in subscribers-only mode, as it did before #677 (which changed the guard to `isSub && minSubMonths > 0`). The 1-month floor still means "any subscriber", so the broadcaster (who counts as a subscriber) and badge-only subs get in; a higher minimum requires real sub months.

**Start button**
- Start is disabled while the entry keyword is empty or whitespace, since a blank keyword matches no message.

**Min sub months field**
- Clearing the field no longer snaps it back to 1 (typing "6" after clearing gave "16"). The field keeps the typed text while focused and shows the stored value, at least 1, on blur.

**Notes**
- With subscribers-only on and a minimum above 1, the broadcaster is rejected because they have no sub months (same on Twitch and Kick). Easy to change if the broadcaster should always be allowed in.
- Not touched: the min duration field has a milder version of the clearing issue (clearing shows "0"), and the winner → overlay handoff.
- Merges cleanly with #687, which edits other parts of `use-raffle-chat.ts` and its tests.

**Testing**
- New `shouldAcceptEntry` tests: subscribers-only off ignores min months (subs below it, non-subs, broadcaster), subscribers-only on enforces it (non-subs rejected, subs below the minimum rejected, at or above accepted, broadcaster at the 1-month floor accepted and above it rejected).
- Two existing tests that expected min months to apply with subscribers-only off now run with it on.
- `vitest run` (102 passed), `tsc --noEmit` (only the known, unrelated `/widgets/alerts` route-tree errors), `biome lint` (no new errors).
