### PR TITLE
fix(extensions): make Sub Sprout setup preview always show the chosen settings

### DIFF
--- a/apps/extensions/src/routes/setup/sub-growing-plant.tsx
+++ b/apps/extensions/src/routes/setup/sub-growing-plant.tsx
@@ -442,7 +442,7 @@ function SubSproutSetup() {
               <h2 className="mb-4 text-xl font-semibold text-center text-zinc-700 dark:text-zinc-300">
                 {t("subSprout.previewTitle")}
               </h2>
-              <div className="flex-1 w-full bg-zinc-950 rounded-lg overflow-hidden border border-zinc-300 relative shadow-inner flex items-center justify-center relative bg-opacity-20 dark:border-zinc-800">
+              <div className="flex-1 w-full bg-zinc-950/20 rounded-lg overflow-hidden border border-zinc-300 relative shadow-inner flex items-center justify-center relative dark:border-zinc-800">
                 {mounted ? (
                   <iframe
                     src={getPreviewUrl()}

--- a/apps/extensions/src/routes/setup/sub-growing-plant.tsx
+++ b/apps/extensions/src/routes/setup/sub-growing-plant.tsx
@@ -145,8 +145,6 @@ function SubSproutSetup() {
   );
   const [twitchChannel, setTwitchChannel] = useState("");
   const [kickChannel, setKickChannel] = useState("");
-  const [debouncedTwitch, setDebouncedTwitch] = useState("");
-  const [debouncedKick, setDebouncedKick] = useState("");
   const [variety, setVariety] = useState<PlantId>("classic");
   const [pick, setPick] = useState<PickMode>("fixed");
   const [water, setWater] = useState<WaterEffectType>("off");
@@ -158,22 +156,6 @@ function SubSproutSetup() {
   useEffect(() => {
     setMounted(true);
   }, []);
-
-  useEffect(() => {
-    const timer = setTimeout(
-      () => setDebouncedTwitch(twitchChannel.trim().toLowerCase()),
-      700,
-    );
-    return () => clearTimeout(timer);
-  }, [twitchChannel]);
-
-  useEffect(() => {
-    const timer = setTimeout(
-      () => setDebouncedKick(kickChannel.trim().toLowerCase()),
-      700,
-    );
-    return () => clearTimeout(timer);
-  }, [kickChannel]);
 
   const buildUrl = (twitch: string, kick: string, withChannel: boolean) => {
     if (typeof window === "undefined") return "";
@@ -198,15 +180,14 @@ function SubSproutSetup() {
       withChannel,
     );
 
+  // simulate=auto stops once the channel's chat connects, leaving the plant at
+  // stage 0 with no setting visible. simulate=1 never connects to chat, so the
+  // channel is left out and the preview keeps growing.
   const getPreviewUrl = () => {
-    const url =
-      buildUrl(debouncedTwitch, debouncedKick, true) ||
-      buildUrl("", "", false);
+    const url = buildUrl("", "", false);
     if (!url) return "";
     const previewUrl = new URL(url);
-    if (!debouncedTwitch && !debouncedKick) {
-      previewUrl.searchParams.set("simulate", "auto");
-    }
+    previewUrl.searchParams.set("simulate", "1");
     return previewUrl.toString();
   };
 
@@ -228,8 +209,6 @@ function SubSproutSetup() {
     variety !== "classic" ||
     !countFx ||
     potLabel;
-  const previewChannel =
-    twitchChannel.trim() || kickChannel.trim();
 
   return (
     <div className="min-h-screen bg-zinc-50 text-zinc-900 font-sans p-6 pt-12 dark:bg-zinc-950 dark:text-zinc-100">
@@ -477,11 +456,7 @@ function SubSproutSetup() {
                 )}
               </div>
               <p className="mt-2 text-center text-xs text-zinc-500">
-                {previewChannel
-                  ? t("subSprout.previewHintChannel", {
-                      channel: previewChannel,
-                    })
-                  : t("subSprout.previewHintNoChannel")}
+                {t("subSprout.previewHintNoChannel")}
               </p>
 
               <div className="mt-4 hidden lg:block">


### PR DESCRIPTION
The Sub Sprout setup preview stopped demonstrating anything once a channel was typed, and its background tint never rendered under Tailwind v4.

**Preview**
- The preview only added `simulate=auto` while both channel fields were empty. With a channel typed it connected to that chat, so the plant sat at stage 0 until a real sub arrived, and variety, watering, sub count effect, pot label and plant changing could not be seen.
- Keeping `simulate=auto` would not help: the widget stops simulating and resets the plant as soon as the chat joins (about a second on Twitch). `simulate=1` never connects to chat.
- The preview now always uses `simulate=1` and leaves the channel out, so it keeps growing with the chosen settings and no longer reloads on every keystroke. The copied widget URL still never contains `simulate`.
- The hint under the preview no longer says the plant grows with the channel's subs, since the preview is simulated. (A dedicated "channel typed" hint needs new copy; follow-up once the i18n files are free.)

**Styling**
- The preview frame used `bg-zinc-950 bg-opacity-20`. Tailwind v4 removed `bg-opacity-*`, so it rendered solid zinc-950. It now uses the intended `bg-zinc-950/20` (a light tint in light mode). No other v3-only utilities were left on the page.

**Testing**
- With a channel typed and non-default settings, the preview iframe src carries every setting plus `simulate=1` and no channel; the copied URL has the channel and settings and no `simulate`.
- The dev server's compiled CSS contains `.bg-zinc-950\/20`.
- `vitest run` passes (99 tests). `tsc` shows only the known, unrelated `/widgets/alerts` route-tree errors. `biome lint` on the page shows no new findings.
