### PR TITLE
fix(extensions): fix crawlability of canonical URLs, sitemap, hreflang and robots.txt

### DIFF
--- a/apps/extensions/README.md
+++ b/apps/extensions/README.md
@@ -15,11 +15,11 @@ Senchabot Extensions provides 100% free streaming widgets, customizable overlays
 ## Live URLs
 
 - [extensions.senchabot.com](https://extensions.senchabot.com/) — Widget and tool hub
-- [Sub Sprout](https://extensions.senchabot.com/setup/sub-growing-plant/)
-- [Universal Chat](https://extensions.senchabot.com/setup/chat-widget/)
-- [Raffle Picker](https://extensions.senchabot.com/setup/raffle/)
-- [OBS Bridge](https://extensions.senchabot.com/setup/obs-bridge/)
-- [Emote Wall](https://extensions.senchabot.com/setup/emote-wall/)
+- [Sub Sprout](https://extensions.senchabot.com/setup/sub-growing-plant)
+- [Universal Chat](https://extensions.senchabot.com/setup/chat-widget)
+- [Raffle Picker](https://extensions.senchabot.com/setup/raffle)
+- [OBS Bridge](https://extensions.senchabot.com/setup/obs-bridge)
+- [Emote Wall](https://extensions.senchabot.com/setup/emote-wall)
 
 ## Widget & Tool Usage
 

--- a/apps/extensions/public/_headers
+++ b/apps/extensions/public/_headers
@@ -1,0 +1,18 @@
+# Workers static assets default to "max-age=0, must-revalidate"; a matching rule replaces it.
+/robots.txt
+  Cache-Control: public, max-age=86400
+
+/sitemap.xml
+  Cache-Control: public, max-age=86400
+
+/llms.txt
+  Cache-Control: public, max-age=86400
+
+/manifest.json
+  Cache-Control: public, max-age=86400
+
+/senchabot-logo.svg
+  Cache-Control: public, max-age=86400
+
+/favicon.ico
+  Cache-Control: public, max-age=604800

--- a/apps/extensions/public/robots.txt
+++ b/apps/extensions/public/robots.txt
@@ -1,7 +1,112 @@
 # https://www.robotstxt.org/robotstxt.html
+# Named groups replace the * group, so each allowed bot repeats the Disallow rules.
 User-agent: *
 Disallow: /widgets/
 Disallow: /tools/
 Allow: /
+
+# AI search, assistant and fetch bots
+User-agent: GPTBot
+Disallow: /widgets/
+Disallow: /tools/
+Allow: /
+
+User-agent: ChatGPT-User
+Disallow: /widgets/
+Disallow: /tools/
+Allow: /
+
+User-agent: OAI-SearchBot
+Disallow: /widgets/
+Disallow: /tools/
+Allow: /
+
+User-agent: ClaudeBot
+Disallow: /widgets/
+Disallow: /tools/
+Allow: /
+
+User-agent: Claude-User
+Disallow: /widgets/
+Disallow: /tools/
+Allow: /
+
+User-agent: Claude-Web
+Disallow: /widgets/
+Disallow: /tools/
+Allow: /
+
+User-agent: Claude-SearchBot
+Disallow: /widgets/
+Disallow: /tools/
+Allow: /
+
+User-agent: anthropic-ai
+Disallow: /widgets/
+Disallow: /tools/
+Allow: /
+
+User-agent: PerplexityBot
+Disallow: /widgets/
+Disallow: /tools/
+Allow: /
+
+User-agent: Perplexity-User
+Disallow: /widgets/
+Disallow: /tools/
+Allow: /
+
+User-agent: Google-Extended
+Disallow: /widgets/
+Disallow: /tools/
+Allow: /
+
+User-agent: Gemini-Deep-Research
+Disallow: /widgets/
+Disallow: /tools/
+Allow: /
+
+User-agent: Google-CloudVertexBot
+Disallow: /widgets/
+Disallow: /tools/
+Allow: /
+
+User-agent: MistralAI-User
+Disallow: /widgets/
+Disallow: /tools/
+Allow: /
+
+User-agent: DuckAssistBot
+Disallow: /widgets/
+Disallow: /tools/
+Allow: /
+
+# Scrapers and training-only bots
+User-agent: Bytespider
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: omgili
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: Meta-ExternalAgent
+Disallow: /
+
+User-agent: Meta-WebIndexer
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: ICC-Crawler
+Disallow: /
 
 Sitemap: https://extensions.senchabot.com/sitemap.xml

--- a/apps/extensions/public/sitemap.xml
+++ b/apps/extensions/public/sitemap.xml
@@ -2,37 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://extensions.senchabot.com/</loc>
-    <lastmod>2026-08-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://extensions.senchabot.com/setup/sub-growing-plant</loc>
-    <lastmod>2026-08-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://extensions.senchabot.com/setup/chat-widget</loc>
-    <lastmod>2026-08-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://extensions.senchabot.com/setup/raffle</loc>
-    <lastmod>2026-08-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://extensions.senchabot.com/setup/obs-bridge</loc>
-    <lastmod>2026-08-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://extensions.senchabot.com/setup/emote-wall</loc>
-    <lastmod>2026-09-03</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>

--- a/apps/extensions/src/lib/i18n/seo.ts
+++ b/apps/extensions/src/lib/i18n/seo.ts
@@ -3,19 +3,19 @@ export const SITE_URL = 'https://extensions.senchabot.com';
 interface LocaleLink {
   rel: string;
   href: string;
-  hreflang?: string;
+  hrefLang?: string;
 }
 
 /**
  * Self-referencing canonical plus hreflang alternates for language variants.
- * Language variants are served via the `?lang=` query param (client-side).
+ * No `tr` alternate yet: Turkish is client-side only (`?lang=`) and the server always
+ * renders English, so crawlers would never see it. Add it once real `/tr/...` URLs exist.
  */
 export function getLocaleLinks(path: string): LocaleLink[] {
   const url = path === '/' || path === '' ? SITE_URL : `${SITE_URL}${path}`;
   return [
     { rel: 'canonical', href: url },
-    { rel: 'alternate', hreflang: 'en', href: url },
-    { rel: 'alternate', hreflang: 'tr', href: `${url}?lang=tr` },
-    { rel: 'alternate', hreflang: 'x-default', href: url },
+    { rel: 'alternate', hrefLang: 'en', href: url },
+    { rel: 'alternate', hrefLang: 'x-default', href: url },
   ];
 }

--- a/apps/extensions/vite.config.ts
+++ b/apps/extensions/vite.config.ts
@@ -25,10 +25,10 @@ const config = defineConfig({
         { path: '/setup/obs-bridge' },
         { path: '/setup/emote-wall' },
       ],
+      // public/sitemap.xml is the source of truth. The generated one overwrote it with an
+      // invalid https:// xmlns and the build date as every page's lastmod.
       sitemap: {
-        enabled: true,
-        host: 'https://extensions.senchabot.com',
-        outputPath: 'sitemap.xml',
+        enabled: false,
       },
     }),
     viteReact(),

--- a/apps/extensions/wrangler.jsonc
+++ b/apps/extensions/wrangler.jsonc
@@ -4,6 +4,11 @@
   "compatibility_date": "2026-03-23",
   "compatibility_flags": ["nodejs_compat"],
   "main": "@tanstack/react-start/server-entry",
+  "assets": {
+    // Prerender writes setup/*/index.html; the default "auto-trailing-slash" would
+    // redirect /setup/x to /setup/x/, away from the canonical no-slash URLs.
+    "html_handling": "drop-trailing-slash"
+  },
   "observability": {
     "enabled": true
   }

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -97,9 +97,9 @@ Open [http://localhost:3000](http://localhost:3000) in your browser.
 ## Related Projects
 
 - [Senchabot Extensions](https://extensions.senchabot.com/) — Free streaming widgets/tools for Twitch and Kick
-  - [Sub Sprout](https://extensions.senchabot.com/setup/sub-growing-plant/)
-  - [Universal Chat](https://extensions.senchabot.com/setup/chat-widget/)
-  - [Raffle](https://extensions.senchabot.com/setup/raffle/)
+  - [Sub Sprout](https://extensions.senchabot.com/setup/sub-growing-plant)
+  - [Universal Chat](https://extensions.senchabot.com/setup/chat-widget)
+  - [Raffle](https://extensions.senchabot.com/setup/raffle)
 
 ## Contributing
 See [CONTRIBUTING.md](../../CONTRIBUTING.md).


### PR DESCRIPTION
Fixes several crawlability issues on extensions.senchabot.com found in an SEO audit.

**Trailing-slash redirects**
- Every canonical/sitemap URL returned `307` to a trailing-slash URL because prerender writes `setup/*/index.html` and Workers assets default to `auto-trailing-slash`.
- Set `assets.html_handling: "drop-trailing-slash"`: `/setup/x` now returns 200 and `/setup/x/` redirects to it.
- README links (extensions and web) no longer use trailing slashes.

**Sitemap**
- TanStack Start's generator overwrote `public/sitemap.xml` with an invalid `https://` sitemaps namespace, stamped the build date as every `lastmod`, and published `/pages.json`.
- Disabled the generator; `public/sitemap.xml` is now the source of truth (all indexable pages, same URLs as the canonicals, no stale `lastmod`).

**hreflang**
- Use React's `hrefLang` prop (fixes the "Invalid DOM property `hreflang`" warning).
- Removed the `tr` alternate: Turkish is client-side only, so `?lang=tr` served English HTML with an English canonical. `en` + `x-default` stay; `tr` comes back with real `/tr/` URLs.

**robots.txt and caching**
- Named groups for AI search/assistant/fetch bots, blocks for bulk scrapers and training-only bots; every allowed group keeps the `/widgets/` and `/tools/` disallows.
- New `public/_headers`: 1 day cache for robots, sitemap, llms.txt, manifest and logo, 7 days for favicon (was `max-age=0, must-revalidate`).

**Testing**
- `vite build` + `vite preview`: `/setup/chat-widget` → 200, `/setup/chat-widget/` → 307 to `/setup/chat-widget`; `/sitemap.xml` has the `http://` namespace and is byte-identical to `public/sitemap.xml`; robots/sitemap/manifest/icons return the new `Cache-Control`; `/_headers` and `/pages.json` → 404.
- Prerendered HTML has `en` and `x-default` alternates only, and every sitemap URL returns 200.
- Python `robotparser`: Googlebot, GPTBot, Claude-User, PerplexityBot can fetch `/` and `/setup/*` but not `/widgets/*` or `/tools/*`; CCBot, Bytespider, Amazonbot are blocked.
- `tsc --noEmit` (only the known, unrelated `/widgets/alerts` route-tree errors), `vitest run` (99 passed), `biome lint` on changed files.
- Not tested on production Cloudflare; the local preview runs the same asset worker and reproduced production's 307 before the fix.
