### PR TITLE
fix(extensions): make structured data match visible page content

### DIFF
--- a/apps/extensions/src/features/widgets/raffle/raffle-widget.tsx
+++ b/apps/extensions/src/features/widgets/raffle/raffle-widget.tsx
@@ -3,10 +3,16 @@ import { YoutubeTutorial } from "#/components/youtube-tutorial";
 import { useRaffleChat } from "#/hooks/use-raffle-chat";
 import { useRaffleState } from "#/hooks/use-raffle-state";
 import { useT } from "#/lib/i18n";
+import type { FaqEntry } from "#/lib/i18n/seo";
 import type { RaffleWinner } from "#/types/raffle";
 import confetti from "canvas-confetti";
 import { Link } from "@tanstack/react-router";
 import { useCallback, useEffect, useRef, useState } from "react";
+
+export const RAFFLE_FAQ: FaqEntry[] = [
+  ["raffle.faq1Q", "raffle.faq1A"],
+  ["raffle.faq2Q", "raffle.faq2A"],
+];
 
 function triggerConfetti(rafRef: React.MutableRefObject<number | null>) {
   const duration = 3000;
@@ -504,25 +510,19 @@ export function RaffleWidget({
               </div>
 
               <div className="space-y-3">
-                <details className="group rounded-lg border border-zinc-200/80 bg-zinc-100/60 p-4 transition-colors open:bg-zinc-100 dark:border-zinc-800/80 dark:bg-zinc-900/50 dark:open:bg-zinc-900">
-                  <summary className="flex cursor-pointer list-none items-center justify-between text-sm font-medium text-zinc-700 group-hover:text-zinc-900 dark:text-zinc-200 dark:group-hover:text-white">
-                    <span>{t("raffle.faq1Q")}</span>
-                    <span className="transition-transform group-open:rotate-180 text-zinc-500 text-xs">▼</span>
-                  </summary>
-                  <p className="mt-2 text-xs text-zinc-600 leading-relaxed dark:text-zinc-400">
-                    {t("raffle.faq1A")}
-                  </p>
-                </details>
-
-                <details className="group rounded-lg border border-zinc-200/80 bg-zinc-100/60 p-4 transition-colors open:bg-zinc-100 dark:border-zinc-800/80 dark:bg-zinc-900/50 dark:open:bg-zinc-900">
-                  <summary className="flex cursor-pointer list-none items-center justify-between text-sm font-medium text-zinc-700 group-hover:text-zinc-900 dark:text-zinc-200 dark:group-hover:text-white">
-                    <span>{t("raffle.faq2Q")}</span>
-                    <span className="transition-transform group-open:rotate-180 text-zinc-500 text-xs">▼</span>
-                  </summary>
-                  <p className="mt-2 text-xs text-zinc-600 leading-relaxed dark:text-zinc-400">
-                    {t("raffle.faq2A")}
-                  </p>
-                </details>
+                {RAFFLE_FAQ.map(([question, answer]) => (
+                  <details
+                    key={question}
+                    className="group rounded-lg border border-zinc-200/80 bg-zinc-100/60 p-4 transition-colors open:bg-zinc-100 dark:border-zinc-800/80 dark:bg-zinc-900/50 dark:open:bg-zinc-900">
+                    <summary className="flex cursor-pointer list-none items-center justify-between text-sm font-medium text-zinc-700 group-hover:text-zinc-900 dark:text-zinc-200 dark:group-hover:text-white">
+                      <span>{t(question)}</span>
+                      <span className="transition-transform group-open:rotate-180 text-zinc-500 text-xs">▼</span>
+                    </summary>
+                    <p className="mt-2 text-xs text-zinc-600 leading-relaxed dark:text-zinc-400">
+                      {t(answer)}
+                    </p>
+                  </details>
+                ))}
               </div>
             </div>
           </div>

--- a/apps/extensions/src/lib/i18n/seo.test.ts
+++ b/apps/extensions/src/lib/i18n/seo.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { en } from './en';
+import { getFaqJsonLd } from './seo';
+
+describe('getFaqJsonLd', () => {
+  it('builds FAQPage questions from the English copy, in order', () => {
+    expect(
+      getFaqJsonLd([
+        ['home.faq1Q', 'home.faq1A'],
+        ['home.faq3Q', 'home.faq3A'],
+      ]),
+    ).toEqual({
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: en.home.faq1Q,
+          acceptedAnswer: { '@type': 'Answer', text: en.home.faq1A },
+        },
+        {
+          '@type': 'Question',
+          name: en.home.faq3Q,
+          acceptedAnswer: { '@type': 'Answer', text: en.home.faq3A },
+        },
+      ],
+    });
+  });
+
+  it('returns an empty mainEntity for no entries', () => {
+    expect(getFaqJsonLd([]).mainEntity).toEqual([]);
+  });
+});

--- a/apps/extensions/src/lib/i18n/seo.ts
+++ b/apps/extensions/src/lib/i18n/seo.ts
@@ -1,3 +1,5 @@
+import { type TranslationKey, translate } from './index';
+
 export const SITE_URL = 'https://extensions.senchabot.com';
 
 interface LocaleLink {
@@ -18,4 +20,23 @@ export function getLocaleLinks(path: string): LocaleLink[] {
     { rel: 'alternate', hreflang: 'tr', href: `${url}?lang=tr` },
     { rel: 'alternate', hreflang: 'x-default', href: url },
   ];
+}
+
+/** A visible FAQ entry as [question key, answer key]. */
+export type FaqEntry = readonly [question: TranslationKey, answer: TranslationKey];
+
+/**
+ * FAQPage JSON-LD built from the same keys the page renders, so the markup always
+ * mirrors the visible Q&A. English, because that is what the prerendered HTML serves.
+ */
+export function getFaqJsonLd(entries: readonly FaqEntry[]) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: entries.map(([question, answer]) => ({
+      '@type': 'Question',
+      name: translate('en', question),
+      acceptedAnswer: { '@type': 'Answer', text: translate('en', answer) },
+    })),
+  };
 }

--- a/apps/extensions/src/routes/index.tsx
+++ b/apps/extensions/src/routes/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { type TranslationKey, useT } from '#/lib/i18n';
-import { getLocaleLinks } from '#/lib/i18n/seo';
+import { type TranslationKey, translate, useT } from '#/lib/i18n';
+import { type FaqEntry, getFaqJsonLd, getLocaleLinks, SITE_URL } from '#/lib/i18n/seo';
 
 export const Route = createFileRoute('/')({
   head: () => ({
@@ -74,98 +74,16 @@ export const Route = createFileRoute('/')({
           '@context': 'https://schema.org',
           '@type': 'ItemList',
           name: 'Free Customizable Stream Overlays, Browser Sources & Stream Tools',
-          itemListElement: [
-            {
-              '@type': 'ListItem',
-              position: 1,
-              name: 'Sub Sprout (Subscriber Goal Plants Overlay)',
-              url: 'https://extensions.senchabot.com/setup/sub-growing-plant',
-              description:
-                'Free subscriber goal plants overlay that grows with new subscriptions on Twitch and Kick.',
-            },
-            {
-              '@type': 'ListItem',
-              position: 2,
-              name: 'Universal Chat (Multi-Chat Widget & Chat Box Overlay)',
-              url: 'https://extensions.senchabot.com/setup/chat-widget',
-              description:
-                'Free customizable multi-chat widget and stream chat box overlay for Twitch and Kick with 7TV emotes.',
-            },
-            {
-              '@type': 'ListItem',
-              position: 3,
-              name: 'Raffle Picker (Chat Giveaway & Contest Tool)',
-              url: 'https://extensions.senchabot.com/setup/raffle',
-              description:
-                'Free chat-based giveaway picker and live confetti winner overlay for Twitch and Kick.',
-            },
-            {
-              '@type': 'ListItem',
-              position: 4,
-              name: 'OBS Bridge (Chat Scene Control & Broadcast Tool)',
-              url: 'https://extensions.senchabot.com/setup/obs-bridge',
-              description:
-                'Free tool to control OBS Studio scenes and recording from chat commands.',
-            },
-            {
-              '@type': 'ListItem',
-              position: 5,
-              name: 'Emote Wall (Floating Emote Overlay)',
-              url: 'https://extensions.senchabot.com/setup/emote-wall',
-              description:
-                'Free floating emote overlay that shows emote-only Twitch, Kick, and 7TV chat messages at random screen positions with Calm, Chaos or Bounce animations.',
-            },
-          ],
+          itemListElement: EXTENSIONS.map((ext, index) => ({
+            '@type': 'ListItem',
+            position: index + 1,
+            name: ext.title,
+            url: `${SITE_URL}${ext.to}`,
+            description: translate('en', `home.${ext.descriptionKey}` as TranslationKey),
+          })),
         },
       },
-      {
-        'script:ld+json': {
-          '@context': 'https://schema.org',
-          '@type': 'FAQPage',
-          mainEntity: [
-            {
-              '@type': 'Question',
-              name: 'Are these customizable stream overlays really free?',
-              acceptedAnswer: {
-                '@type': 'Answer',
-                text: 'Yes, all multi-chat widgets, subscriber goal plants, and stream overlays are 100% free, open-source, and watermark-free with no paid tiers.',
-              },
-            },
-            {
-              '@type': 'Question',
-              name: 'Do I need to create an account or sign in to use the chat box widget?',
-              acceptedAnswer: {
-                '@type': 'Answer',
-                text: 'No login or account is required. Enter your Twitch or Kick channel name, customize your chat box or overlay, copy the URL, and paste it into OBS.',
-              },
-            },
-            {
-              '@type': 'Question',
-              name: 'Which streaming software is supported?',
-              acceptedAnswer: {
-                '@type': 'Answer',
-                text: 'Works with OBS, Streamlabs Desktop, XSplit, vMix, Lightstream, or any software that supports browser sources.',
-              },
-            },
-            {
-              '@type': 'Question',
-              name: 'How do I add a chat widget or subscriber goal plant that supports multiple platforms to OBS Studio?',
-              acceptedAnswer: {
-                '@type': 'Answer',
-                text: 'Configure your widget, copy the URL, add a Browser Source in OBS Studio, and paste the URL.',
-              },
-            },
-            {
-              '@type': 'Question',
-              name: 'What is the Emote Wall overlay and which messages trigger it?',
-              acceptedAnswer: {
-                '@type': 'Answer',
-                text: 'Emote Wall is a free browser source overlay that turns emote-only Twitch, Kick, and 7TV chat messages into floating on-screen emotes. Only messages containing nothing but emotes trigger it; normal text messages are ignored. Choose Calm mode for emotes that pop up at random spots and drift away, Chaos mode for emotes that zip across the screen from random edges, or Bounce mode for emotes that ricochet off the edges and speed up with every hit.',
-              },
-            },
-          ],
-        },
-      },
+      { 'script:ld+json': getFaqJsonLd(FAQ) },
     ],
     links: getLocaleLinks('/'),
   }),
@@ -213,6 +131,13 @@ const EXTENSIONS = [
     title: 'OBS Bridge',
     descriptionKey: 'cardObsBridge' as TranslationKey,
   }
+];
+
+const FAQ: FaqEntry[] = [
+  ['home.faq1Q', 'home.faq1A'],
+  ['home.faq2Q', 'home.faq2A'],
+  ['home.faq3Q', 'home.faq3A'],
+  ['home.faq4Q', 'home.faq4A'],
 ];
 
 function Index() {
@@ -290,53 +215,22 @@ function Index() {
             {t('home.faqTitle')}
           </h2>
           <div className="space-y-3">
-            <details className="group rounded-lg border border-zinc-200/80 bg-zinc-100/60 p-4 transition-colors open:bg-zinc-100 dark:border-zinc-800/80 dark:bg-zinc-900/50 dark:open:bg-zinc-900">
-              <summary className="flex cursor-pointer list-none items-center justify-between text-sm font-medium text-zinc-700 group-hover:text-zinc-900 dark:text-zinc-200 dark:group-hover:text-white">
-                <span>{t('home.faq1Q')}</span>
-                <span className="transition-transform group-open:rotate-180 text-zinc-500 text-xs">
-                  ▼
-                </span>
-              </summary>
-              <p className="mt-2 text-xs text-zinc-600 leading-relaxed dark:text-zinc-400">
-                {t('home.faq1A')}
-              </p>
-            </details>
-
-            <details className="group rounded-lg border border-zinc-200/80 bg-zinc-100/60 p-4 transition-colors open:bg-zinc-100 dark:border-zinc-800/80 dark:bg-zinc-900/50 dark:open:bg-zinc-900">
-              <summary className="flex cursor-pointer list-none items-center justify-between text-sm font-medium text-zinc-700 group-hover:text-zinc-900 dark:text-zinc-200 dark:group-hover:text-white">
-                <span>{t('home.faq2Q')}</span>
-                <span className="transition-transform group-open:rotate-180 text-zinc-500 text-xs">
-                  ▼
-                </span>
-              </summary>
-              <p className="mt-2 text-xs text-zinc-600 leading-relaxed dark:text-zinc-400">
-                {t('home.faq2A')}
-              </p>
-            </details>
-
-            <details className="group rounded-lg border border-zinc-200/80 bg-zinc-100/60 p-4 transition-colors open:bg-zinc-100 dark:border-zinc-800/80 dark:bg-zinc-900/50 dark:open:bg-zinc-900">
-              <summary className="flex cursor-pointer list-none items-center justify-between text-sm font-medium text-zinc-700 group-hover:text-zinc-900 dark:text-zinc-200 dark:group-hover:text-white">
-                <span>{t('home.faq3Q')}</span>
-                <span className="transition-transform group-open:rotate-180 text-zinc-500 text-xs">
-                  ▼
-                </span>
-              </summary>
-              <p className="mt-2 text-xs text-zinc-600 leading-relaxed dark:text-zinc-400">
-                {t('home.faq3A')}
-              </p>
-            </details>
-
-            <details className="group rounded-lg border border-zinc-200/80 bg-zinc-100/60 p-4 transition-colors open:bg-zinc-100 dark:border-zinc-800/80 dark:bg-zinc-900/50 dark:open:bg-zinc-900">
-              <summary className="flex cursor-pointer list-none items-center justify-between text-sm font-medium text-zinc-700 group-hover:text-zinc-900 dark:text-zinc-200 dark:group-hover:text-white">
-                <span>{t('home.faq4Q')}</span>
-                <span className="transition-transform group-open:rotate-180 text-zinc-500 text-xs">
-                  ▼
-                </span>
-              </summary>
-              <p className="mt-2 text-xs text-zinc-600 leading-relaxed dark:text-zinc-400">
-                {t('home.faq4A')}
-              </p>
-            </details>
+            {FAQ.map(([question, answer]) => (
+              <details
+                key={question}
+                className="group rounded-lg border border-zinc-200/80 bg-zinc-100/60 p-4 transition-colors open:bg-zinc-100 dark:border-zinc-800/80 dark:bg-zinc-900/50 dark:open:bg-zinc-900"
+              >
+                <summary className="flex cursor-pointer list-none items-center justify-between text-sm font-medium text-zinc-700 group-hover:text-zinc-900 dark:text-zinc-200 dark:group-hover:text-white">
+                  <span>{t(question)}</span>
+                  <span className="transition-transform group-open:rotate-180 text-zinc-500 text-xs">
+                    ▼
+                  </span>
+                </summary>
+                <p className="mt-2 text-xs text-zinc-600 leading-relaxed dark:text-zinc-400">
+                  {t(answer)}
+                </p>
+              </details>
+            ))}
           </div>
         </section>
 

--- a/apps/extensions/src/routes/setup/emote-wall.tsx
+++ b/apps/extensions/src/routes/setup/emote-wall.tsx
@@ -1,7 +1,7 @@
 import { Breadcrumb } from '#/components/breadcrumb';
 import { YoutubeTutorial } from '#/components/youtube-tutorial';
 import { useI18n } from '#/lib/i18n';
-import { getLocaleLinks } from '#/lib/i18n/seo';
+import { type FaqEntry, getFaqJsonLd, getLocaleLinks } from '#/lib/i18n/seo';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { useDeferredValue, useEffect, useMemo, useState } from 'react';
 
@@ -75,35 +75,17 @@ export const Route = createFileRoute('/setup/emote-wall')({
           },
         },
       },
-      {
-        'script:ld+json': {
-          '@context': 'https://schema.org',
-          '@type': 'FAQPage',
-          mainEntity: [
-            {
-              '@type': 'Question',
-              name: 'Which messages trigger the emote wall?',
-              acceptedAnswer: {
-                '@type': 'Answer',
-                text: 'Only messages that contain nothing but emotes (Twitch, Kick, or 7TV emotes, optionally repeated) trigger a floating on-screen emote. Normal text messages are ignored.',
-              },
-            },
-            {
-              '@type': 'Question',
-              name: 'Do I need to sign in to use the emote wall?',
-              acceptedAnswer: {
-                '@type': 'Answer',
-                text: 'No login is required. Emote Wall listens anonymously to public chat streams for both platforms.',
-              },
-            },
-          ],
-        },
-      },
+      { 'script:ld+json': getFaqJsonLd(FAQ) },
     ],
     links: getLocaleLinks('/setup/emote-wall'),
   }),
   component: EmoteWallSetup,
 });
+
+const FAQ: FaqEntry[] = [
+  ['emoteWallSetup.faq1Q', 'emoteWallSetup.faq1A'],
+  ['emoteWallSetup.faq2Q', 'emoteWallSetup.faq2A'],
+];
 
 function EmoteWallSetup() {
   const { locale, t } = useI18n();
@@ -552,29 +534,22 @@ function EmoteWallSetup() {
               </div>
 
               <div className="space-y-3">
-                <details className="group rounded-lg border border-zinc-200/80 bg-zinc-100/60 p-4 transition-colors open:bg-zinc-100 dark:border-zinc-800/80 dark:bg-zinc-900/50 dark:open:bg-zinc-900">
-                  <summary className="flex cursor-pointer list-none items-center justify-between text-sm font-medium text-zinc-700 group-hover:text-zinc-900 dark:text-zinc-200 dark:group-hover:text-white">
-                    <span>{t('emoteWallSetup.faq1Q')}</span>
-                    <span className="transition-transform group-open:rotate-180 text-zinc-500 text-xs">
-                      ▼
-                    </span>
-                  </summary>
-                  <p className="mt-2 text-xs text-zinc-600 leading-relaxed dark:text-zinc-400">
-                    {t('emoteWallSetup.faq1A')}
-                  </p>
-                </details>
-
-                <details className="group rounded-lg border border-zinc-200/80 bg-zinc-100/60 p-4 transition-colors open:bg-zinc-100 dark:border-zinc-800/80 dark:bg-zinc-900/50 dark:open:bg-zinc-900">
-                  <summary className="flex cursor-pointer list-none items-center justify-between text-sm font-medium text-zinc-700 group-hover:text-zinc-900 dark:text-zinc-200 dark:group-hover:text-white">
-                    <span>{t('emoteWallSetup.faq2Q')}</span>
-                    <span className="transition-transform group-open:rotate-180 text-zinc-500 text-xs">
-                      ▼
-                    </span>
-                  </summary>
-                  <p className="mt-2 text-xs text-zinc-600 leading-relaxed dark:text-zinc-400">
-                    {t('emoteWallSetup.faq2A')}
-                  </p>
-                </details>
+                {FAQ.map(([question, answer]) => (
+                  <details
+                    key={question}
+                    className="group rounded-lg border border-zinc-200/80 bg-zinc-100/60 p-4 transition-colors open:bg-zinc-100 dark:border-zinc-800/80 dark:bg-zinc-900/50 dark:open:bg-zinc-900"
+                  >
+                    <summary className="flex cursor-pointer list-none items-center justify-between text-sm font-medium text-zinc-700 group-hover:text-zinc-900 dark:text-zinc-200 dark:group-hover:text-white">
+                      <span>{t(question)}</span>
+                      <span className="transition-transform group-open:rotate-180 text-zinc-500 text-xs">
+                        ▼
+                      </span>
+                    </summary>
+                    <p className="mt-2 text-xs text-zinc-600 leading-relaxed dark:text-zinc-400">
+                      {t(answer)}
+                    </p>
+                  </details>
+                ))}
               </div>
             </div>
           </div>

--- a/apps/extensions/src/routes/setup/raffle.tsx
+++ b/apps/extensions/src/routes/setup/raffle.tsx
@@ -1,6 +1,6 @@
-import { RaffleWidget } from "#/features/widgets/raffle/raffle-widget";
+import { RAFFLE_FAQ, RaffleWidget } from "#/features/widgets/raffle/raffle-widget";
 import { createFileRoute } from "@tanstack/react-router";
-import { getLocaleLinks } from "#/lib/i18n/seo";
+import { getFaqJsonLd, getLocaleLinks } from "#/lib/i18n/seo";
 import { z } from "zod";
 
 const searchSchema = z.object({
@@ -80,75 +80,7 @@ export const Route = createFileRoute("/setup/raffle")({
           },
         },
       },
-      {
-        "script:ld+json": {
-          "@context": "https://schema.org",
-          "@type": "HowTo",
-          name: "How to Run a Free Stream Giveaway on Twitch and Kick",
-          description:
-            "Step-by-step instructions to run interactive viewer giveaways with chat keyword entry in OBS Studio, Streamlabs Desktop, XSplit, or any software supporting browser sources.",
-          step: [
-            {
-              "@type": "HowToStep",
-              name: "Set Channel & Entry Keyword",
-              text: "Choose Twitch or Kick, enter your channel, and specify your giveaway keyword (e.g. !join).",
-              position: 1,
-            },
-            {
-              "@type": "HowToStep",
-              name: "Start Giveaway & Collect Entries",
-              text: "Click 'Start Raffle'. Viewers entering the keyword in chat are automatically added to the live entries list.",
-              position: 2,
-            },
-            {
-              "@type": "HowToStep",
-              name: "Draw Random Winner & Celebrate",
-              text: "Click 'Draw Winner' to randomly pick a winner with fireworks and confetti on your overlay.",
-              position: 3,
-            },
-          ],
-        },
-      },
-      {
-        "script:ld+json": {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          mainEntity: [
-            {
-              "@type": "Question",
-              name: "Is this giveaway tool free to use?",
-              acceptedAnswer: {
-                "@type": "Answer",
-                text: "Yes, this stream raffle tool is 100% free and open source with no hidden costs, limits, or account sign-ups.",
-              },
-            },
-            {
-              "@type": "Question",
-              name: "Do viewers or streamers need to log in?",
-              acceptedAnswer: {
-                "@type": "Answer",
-                text: "No login is needed. Streamers only provide their channel name, and viewers enter simply by chatting your keyword in Twitch or Kick chat.",
-              },
-            },
-            {
-              "@type": "Question",
-              name: "Can I restrict the raffle to subscribers only?",
-              acceptedAnswer: {
-                "@type": "Answer",
-                text: "Yes, you can enable 'Subscribers Only' and set a minimum subscribed months filter to reward loyal community members.",
-              },
-            },
-            {
-              "@type": "Question",
-              name: "How does the winner celebration overlay work?",
-              acceptedAnswer: {
-                "@type": "Answer",
-                text: "Add '/widgets/raffle-overlay' as a browser source in OBS Studio, Streamlabs Desktop, XSplit, vMix, Lightstream, PRISM Live Studio, or any software supporting browser sources. When you draw a winner on the setup dashboard, the overlay immediately triggers a confetti celebration banner on stream.",
-              },
-            },
-          ],
-        },
-      },
+      { "script:ld+json": getFaqJsonLd(RAFFLE_FAQ) },
     ],
     links: getLocaleLinks("/setup/raffle"),
   }),

--- a/apps/extensions/src/routes/setup/sub-growing-plant.tsx
+++ b/apps/extensions/src/routes/setup/sub-growing-plant.tsx
@@ -1,7 +1,7 @@
 import { Breadcrumb } from "#/components/breadcrumb";
 import { YoutubeTutorial } from "#/components/youtube-tutorial";
 import { useT, type TranslationKey } from "#/lib/i18n";
-import { getLocaleLinks } from "#/lib/i18n/seo";
+import { type FaqEntry, getFaqJsonLd, getLocaleLinks } from "#/lib/i18n/seo";
 import {
   PLANT_REGISTRY,
   PLANT_IDS,
@@ -84,57 +84,17 @@ export const Route = createFileRoute("/setup/sub-growing-plant")({
           },
         },
       },
-      {
-        "script:ld+json": {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          mainEntity: [
-            {
-              "@type": "Question",
-              name: "Are subscriber goal plants on Sub Sprout completely free?",
-              acceptedAnswer: {
-                "@type": "Answer",
-                text: "Yes, Sub Sprout is 100% free and open-source with no subscription fees, account sign-ups, or watermarks.",
-              },
-            },
-            {
-              "@type": "Question",
-              name: "Do I need to sign in with Twitch or Kick to use the subscriber goal plant?",
-              acceptedAnswer: {
-                "@type": "Answer",
-                text: "No login is required. Sub Sprout connects to public chat and subscription events directly from your browser source URL.",
-              },
-            },
-            {
-              "@type": "Question",
-              name: "How do I test the subscriber goal plant on stream?",
-              acceptedAnswer: {
-                "@type": "Answer",
-                text: "Broadcasters and channel moderators can type the '!grow' command in chat to test or manually advance the plant.",
-              },
-            },
-          ],
-        },
-      },
-      {
-        "script:ld+json": {
-          "@context": "https://schema.org",
-          "@type": "VideoObject",
-          name: "Sub Sprout Subscriber Goal Plant Tutorial",
-          description:
-            "Step-by-step tutorial on how to configure the Sub Sprout subscriber goal plant and sub alert widget for Twitch and Kick streams.",
-          thumbnailUrl: "https://img.youtube.com/vi/P0Btpez9Znw/maxresdefault.jpg",
-          embedUrl: "https://www.youtube.com/embed/P0Btpez9Znw",
-          contentUrl: "https://youtu.be/P0Btpez9Znw",
-          uploadDate: "2025-04-11T12:00:00+03:00",
-          duration: "PT43S",
-        },
-      },
+      { "script:ld+json": getFaqJsonLd(FAQ) },
     ],
     links: getLocaleLinks("/setup/sub-growing-plant"),
   }),
   component: SubSproutSetup,
 });
+
+const FAQ: FaqEntry[] = [
+  ["subSprout.faq1Q", "subSprout.faq1A"],
+  ["subSprout.faq2Q", "subSprout.faq2A"],
+];
 
 type PickMode = "fixed" | "cycle" | "random";
 
@@ -521,25 +481,19 @@ function SubSproutSetup() {
               </div>
 
               <div className="space-y-3">
-                <details className="group rounded-lg border border-zinc-200/80 bg-zinc-100/60 p-4 transition-colors open:bg-zinc-100 dark:border-zinc-800/80 dark:bg-zinc-900/50 dark:open:bg-zinc-900">
-                  <summary className="flex cursor-pointer list-none items-center justify-between text-sm font-medium text-zinc-700 group-hover:text-zinc-900 dark:text-zinc-200 dark:group-hover:text-white">
-                    <span>{t("subSprout.faq1Q")}</span>
-                    <span className="transition-transform group-open:rotate-180 text-zinc-500 text-xs">▼</span>
-                  </summary>
-                  <p className="mt-2 text-xs text-zinc-600 leading-relaxed dark:text-zinc-400">
-                    {t("subSprout.faq1A")}
-                  </p>
-                </details>
-
-                <details className="group rounded-lg border border-zinc-200/80 bg-zinc-100/60 p-4 transition-colors open:bg-zinc-100 dark:border-zinc-800/80 dark:bg-zinc-900/50 dark:open:bg-zinc-900">
-                  <summary className="flex cursor-pointer list-none items-center justify-between text-sm font-medium text-zinc-700 group-hover:text-zinc-900 dark:text-zinc-200 dark:group-hover:text-white">
-                    <span>{t("subSprout.faq2Q")}</span>
-                    <span className="transition-transform group-open:rotate-180 text-zinc-500 text-xs">▼</span>
-                  </summary>
-                  <p className="mt-2 text-xs text-zinc-600 leading-relaxed dark:text-zinc-400">
-                    {t("subSprout.faq2A")}
-                  </p>
-                </details>
+                {FAQ.map(([question, answer]) => (
+                  <details
+                    key={question}
+                    className="group rounded-lg border border-zinc-200/80 bg-zinc-100/60 p-4 transition-colors open:bg-zinc-100 dark:border-zinc-800/80 dark:bg-zinc-900/50 dark:open:bg-zinc-900">
+                    <summary className="flex cursor-pointer list-none items-center justify-between text-sm font-medium text-zinc-700 group-hover:text-zinc-900 dark:text-zinc-200 dark:group-hover:text-white">
+                      <span>{t(question)}</span>
+                      <span className="transition-transform group-open:rotate-180 text-zinc-500 text-xs">▼</span>
+                    </summary>
+                    <p className="mt-2 text-xs text-zinc-600 leading-relaxed dark:text-zinc-400">
+                      {t(answer)}
+                    </p>
+                  </details>
+                ))}
               </div>
             </div>
           </div>


### PR DESCRIPTION
Google requires FAQPage markup to mirror the Q&A visible on the page. On extensions.senchabot.com the JSON-LD was hand-written separately from the visible FAQ and had drifted (extra questions, reworded questions, different answers). Some pages also had markup describing content that isn't on the page.

**What changed**
- Added `getFaqJsonLd()` in `src/lib/i18n/seo.ts`: it builds a FAQPage from `[questionKey, answerKey]` i18n pairs using the English copy (what the prerendered HTML serves).
- Home, Sub Sprout, Raffle and Emote Wall each declare their FAQ keys once and use them for both the visible `<details>` list and `head()`, so the two can't drift again.
- Schema-only questions with no visible counterpart were dropped.
- Home `ItemList` is now built from the same array that renders the cards (names, URLs, order and descriptions match; e.g. "Chat Box" instead of "Universal Chat").
- Removed the Raffle `HowTo` (the guide is a single paragraph, not steps) and the Sub Sprout `VideoObject` (the tutorial is only linked, not embedded, and its `uploadDate` predated the app).

**Not in this PR**
- Chat Box and OBS Bridge setup pages get the same treatment in a follow-up (their files are in open PRs).
- Visible copy is unchanged; questions worth adding visibly later: Emote Wall on home, "is it free" / `!grow` on Sub Sprout, login and sub-only on Raffle.

**Testing**
- `tsc --noEmit` (only the known, unrelated `/widgets/alerts` route-tree errors), `vitest run` (101 passed, including a new `getFaqJsonLd` test), `biome lint` on changed files (no new diagnostics).
- `vite build`, then extracted the JSON-LD and the visible FAQ from `dist/client` for `/`, `/setup/sub-growing-plant`, `/setup/raffle` and `/setup/emote-wall`: questions and answers match exactly, and the home ItemList matches the cards.
- Diffed the rendered page body against a build of `dev`: the visible HTML is identical.
- Merges cleanly with the other open extensions PRs (#696, #697, #698, #699).
