### PR TITLE
feat(extensions): switch site UI font to Geist

### DIFF
--- a/apps/extensions/src/routes/__root.tsx
+++ b/apps/extensions/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import { createRootRoute, HeadContent, Scripts } from '@tanstack/react-router';
+import { createRootRoute, HeadContent, Scripts, useLocation } from '@tanstack/react-router';
 
 import { SettingsControls } from '#/components/settings-controls';
 import { LocaleProvider } from '#/lib/i18n';
@@ -9,8 +9,22 @@ import appCss from '../styles.css?url';
 // Runs before first paint to avoid a flash of the wrong theme/language.
 const themeInitScript = `(function(){try{var t=localStorage.getItem("theme");var d=t?t==="dark":!window.matchMedia||window.matchMedia("(prefers-color-scheme: dark)").matches;var el=document.documentElement;el.classList.toggle("dark",d);el.style.colorScheme=d?"dark":"light";var l=new URLSearchParams(location.search).get("lang")||localStorage.getItem("lang");if(l)el.lang=l;var m=document.querySelector('meta[name="theme-color"]');if(m)m.setAttribute("content",d?"#09090b":"#fafafa")}catch(e){}})();`;
 
+// Overlays run inside streamers' OBS scenes: they keep their old font and never download Geist.
+const isWidgetPath = (pathname: string) => pathname.startsWith('/widgets/');
+
+// Geist is variable, so one 400..800 range (the weights the site uses) serves one file per subset.
+const geistLinks = [
+  { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
+  { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossOrigin: 'anonymous' as const },
+  {
+    rel: 'stylesheet',
+    href: 'https://fonts.googleapis.com/css2?family=Geist:wght@400..800&display=swap',
+  },
+];
+
 export const Route = createRootRoute({
-  head: () => ({
+  // Root head sees every match, so this is the one place that can skip Geist for all widget routes.
+  head: ({ matches }) => ({
     meta: [
       {
         charSet: 'utf-8',
@@ -63,6 +77,7 @@ export const Route = createRootRoute({
         rel: 'stylesheet',
         href: appCss,
       },
+      ...(matches.some((match) => isWidgetPath(match.pathname)) ? [] : geistLinks),
       {
         rel: 'icon',
         href: '/favicon.ico',
@@ -77,6 +92,8 @@ export const Route = createRootRoute({
 });
 
 function RootDocument({ children }: { children: React.ReactNode }) {
+  const isWidget = useLocation({ select: (location) => isWidgetPath(location.pathname) });
+
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
@@ -84,7 +101,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
         <HeadContent />
       </head>
-      <body className="font-sans antialiased min-h-screen">
+      <body className={`${isWidget ? 'font-widget' : 'font-sans'} antialiased min-h-screen`}>
         <ThemeProvider>
           <LocaleProvider>
             {children}

--- a/apps/extensions/src/styles.css
+++ b/apps/extensions/src/styles.css
@@ -3,10 +3,10 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
-@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;500;700;900&display=swap');
-
 @theme {
-  --font-sans: "Consolas", ui-sans-serif, system-ui, sans-serif;
+  --font-sans: "Geist", ui-sans-serif, system-ui, sans-serif;
+  /* Overlays keep the pre-Geist stack so streamers' OBS scenes don't change. */
+  --font-widget: "Consolas", ui-sans-serif, system-ui, sans-serif;
   --font-display: "Orbitron", sans-serif;
 }
 


### PR DESCRIPTION
Switches the extensions site from Consolas to Geist, the font senchabot.com uses. Overlays under `/widgets/*` keep their current font, so streamers' OBS scenes don't change.

**Why**
- Consolas is a Windows-only monospace font, so the site looked different on every OS and didn't match senchabot.com.

**Changes**
- `--font-sans` is now Geist, loaded from Google Fonts in the root head: preconnects plus one variable `wght@400..800` range (the weights the pages use) with `display=swap`. No new npm package.
- The root head leaves out the Geist links on `/widgets/*`, and `body` uses a new `font-widget` token there that keeps the previous Consolas stack.
- Removed the Orbitron `@import` from `styles.css`: it came after other rules, so the build always dropped it (`@import rules must precede all rules…`) and it never loaded. Loading Orbitron where it's actually used is a separate PR, since that one does change how the alert card looks.

**Overlay fonts (unchanged)**
- Chat widget: its own `font` param / `FONT_STACKS`.
- Emote wall, Sub Sprout (pot label, count FX), raffle overlay: previous Consolas stack via `font-widget`.
- Alerts: same generic sans-serif fallback as before.

**Testing**
- `tsc --noEmit`, `vitest run` (99 passed), `vite build` (no `@import` warning anymore).
- Prerendered `/` and `/setup/*` link Geist, with `body.font-sans`.
- Dev SSR: `/tools/obs-bridge` links Geist; every `/widgets/*` route links no Google fonts and renders `body.font-widget`.
