### PR TITLE
fix(extensions): load Orbitron for the alerts widget

### DIFF
--- a/apps/extensions/src/routes/widgets/alerts.tsx
+++ b/apps/extensions/src/routes/widgets/alerts.tsx
@@ -21,6 +21,16 @@ interface FollowData {
 export const Route = createFileRoute('/widgets/alerts')({
   ssr: false,
   validateSearch: (search) => searchSchema.parse(search),
+  // Only the alert card uses font-display (400 and 700), so Orbitron loads here, not site-wide.
+  head: () => ({
+    links: [
+      { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossOrigin: 'anonymous' },
+      {
+        rel: 'stylesheet',
+        href: 'https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap',
+      },
+    ],
+  }),
   component: RouteComponent,
 });
 


### PR DESCRIPTION
The alert card uses `font-display` (Orbitron), but the font was only ever requested by an `@import` in `styles.css` that came after other rules, so the build dropped it (`@import rules must precede all rules…`). The card has always rendered in the generic sans-serif fallback.

**Change**
- Load Orbitron from the `/widgets/alerts` route head, with only the 400 and 700 weights the card uses. The site and the other overlays never fetch it.

**Heads-up**
- This visibly changes the alert card in OBS: type label, name and amount switch from the fallback sans-serif to Orbitron, the font the card was designed with. Close this PR if the current look should stay.
- Independent of the Geist PR (#701), which removes the dead `@import`.

**Testing**
- `tsc --noEmit`: no new errors (only the known `/widgets/alerts` route-tree errors).
- Dev SSR: `/widgets/alerts?kick=test` links the Orbitron stylesheet and the gstatic preconnect.
