### PR TITLE
feat(extensions): add a growth speed slider to the Sub Sprout preview

### DIFF
--- a/apps/extensions/src/features/widgets/sub-sprout/sub-sprout-widget.tsx
+++ b/apps/extensions/src/features/widgets/sub-sprout/sub-sprout-widget.tsx
@@ -29,6 +29,8 @@ export interface SubSproutWidgetProps {
   countFx?: boolean;
   potLabel?: boolean;
   simulate?: boolean | "auto";
+  /** Fast-forwards the simulated subs, for the setup page's preview speed slider. */
+  simSpeed?: number;
 }
 
 const VIEWBOX_W = 800;
@@ -111,11 +113,18 @@ export function SubSproutWidget({
   countFx = true,
   potLabel = false,
   simulate = false,
+  simSpeed = 1,
 }: SubSproutWidgetProps) {
   const safeVariety = isValidPlantId(variety) ? variety : "classic";
   const safePick: PickMode =
     pick === "cycle" || pick === "random" || pick === "fixed" ? pick : "fixed";
   const safeWater: WaterEffectType = isValidWaterEffect(water) ? water : "off";
+  // Every timing scales together so the preview plays like a fast-forward, not cut-off effects.
+  // Real subs always run at 1x, even if the param ends up in an OBS URL.
+  const speed = simulate && simSpeed > 0 ? simSpeed : 1;
+  const growthIntervalMs = ANIMATION_INTERVAL_MS / speed;
+  const waterDurationMs = WATER_EFFECT_DURATION_MS / speed;
+  const countDurationMs = SUB_COUNT_DURATION_MS / speed;
 
   const [currentVariety, setCurrentVariety] = useState<PlantId>(
     () => safeVariety,
@@ -224,8 +233,8 @@ export function SubSproutWidget({
     setTimeout(() => {
       isAnimating.current = false;
       processQueue();
-    }, ANIMATION_INTERVAL_MS);
-  }, [applyGrowth]);
+    }, growthIntervalMs);
+  }, [applyGrowth, growthIntervalMs]);
 
   const handleSubEvent = useCallback(
     (amount: number = 1) => {
@@ -272,13 +281,12 @@ export function SubSproutWidget({
       if (cancelled) return;
       const amount = Math.random() < 0.5 ? 1 : 2;
       handleSubEvent(amount);
-      const growthMs = amount * ANIMATION_INTERVAL_MS;
-      const fxMs = countFx ? SUB_COUNT_DURATION_MS : 0;
-      const waterMs =
-        safeWater !== "off" ? WATER_EFFECT_DURATION_MS : 0;
+      const growthMs = amount * growthIntervalMs;
+      const fxMs = countFx ? countDurationMs : 0;
+      const waterMs = safeWater !== "off" ? waterDurationMs : 0;
       timer = window.setTimeout(
         scheduleNext,
-        Math.max(growthMs, fxMs, waterMs) + SIM_NEXT_GAP_MS,
+        Math.max(growthMs, fxMs, waterMs) + SIM_NEXT_GAP_MS / speed,
       );
     };
 
@@ -287,7 +295,17 @@ export function SubSproutWidget({
       cancelled = true;
       if (timer !== undefined) window.clearTimeout(timer);
     };
-  }, [simulate, joined, handleSubEvent, countFx, safeWater]);
+  }, [
+    simulate,
+    joined,
+    handleSubEvent,
+    countFx,
+    safeWater,
+    speed,
+    growthIntervalMs,
+    countDurationMs,
+    waterDurationMs,
+  ]);
 
   useEffect(() => {
     twitchConnectedRef.current = false;
@@ -610,12 +628,9 @@ export function SubSproutWidget({
 
   useEffect(() => {
     if (!activeWaterSlot) return;
-    const t = setTimeout(
-      () => setActiveWaterSlot(null),
-      WATER_EFFECT_DURATION_MS,
-    );
+    const t = setTimeout(() => setActiveWaterSlot(null), waterDurationMs);
     return () => clearTimeout(t);
-  }, [activeWaterSlot]);
+  }, [activeWaterSlot, waterDurationMs]);
 
   if (currentVariety === "vine") {
     const first = slotStates[0] ?? { stagesDone: 0, progress: 0 };
@@ -623,7 +638,11 @@ export function SubSproutWidget({
       <div className="size-full">
         <VineOverlay stage={first.stagesDone} progress={first.progress} />
         {countFx && subCountFx && (
-          <SubCountFX count={subCountFx.count} triggerKey={subCountFx.key} />
+          <SubCountFX
+            count={subCountFx.count}
+            triggerKey={subCountFx.key}
+            durationMs={countDurationMs}
+          />
         )}
       </div>
     );
@@ -636,14 +655,18 @@ export function SubSproutWidget({
       <div className="relative size-full">
         <LegacySubSproutSvg step={step} potLabel={potLabel} />
         {countFx && subCountFx && (
-          <SubCountFX count={subCountFx.count} triggerKey={subCountFx.key} />
+          <SubCountFX
+            count={subCountFx.count}
+            triggerKey={subCountFx.key}
+            durationMs={countDurationMs}
+          />
         )}
         {activeWaterSlot && safeWater !== "off" && (
           <WateringFX
             key={activeWaterSlot.key}
             effect={safeWater}
             active
-            durationMs={WATER_EFFECT_DURATION_MS}
+            durationMs={waterDurationMs}
           />
         )}
       </div>
@@ -685,12 +708,16 @@ export function SubSproutWidget({
           key={activeWaterSlot.key}
           effect={safeWater}
           active
-          durationMs={WATER_EFFECT_DURATION_MS}
+          durationMs={waterDurationMs}
         />
       )}
 
       {countFx && subCountFx && (
-        <SubCountFX count={subCountFx.count} triggerKey={subCountFx.key} />
+        <SubCountFX
+          count={subCountFx.count}
+          triggerKey={subCountFx.key}
+          durationMs={countDurationMs}
+        />
       )}
     </div>
   );

--- a/apps/extensions/src/lib/i18n/en.ts
+++ b/apps/extensions/src/lib/i18n/en.ts
@@ -462,6 +462,8 @@ export const en = {
     potLabelTip: "Writes the stage on the pot, like 3/10. Climbing Vine doesn't show it.",
     previewTitle: 'Subscriber Goal Plant Preview',
     previewIframeTitle: 'Sub Sprout Preview',
+    previewSpeed: 'Preview Growth Speed',
+    previewSpeedValue: '{rate}×',
     previewHint:
       'The preview grows with simulated subs. On stream, your plant grows with real subs, resubs and gifted subs in your channel.',
     widgetUrlTip:

--- a/apps/extensions/src/lib/i18n/tr.ts
+++ b/apps/extensions/src/lib/i18n/tr.ts
@@ -464,6 +464,8 @@ export const tr: typeof en = {
     potLabelTip: "Saksının üstüne aşamayı yazar, örneğin 3/10. Sarmaşık'ta görünmez.",
     previewTitle: 'Abone Hedefi Bitkisi Önizleme',
     previewIframeTitle: 'Sub Sprout Önizleme',
+    previewSpeed: 'Önizleme Büyüme Hızı',
+    previewSpeedValue: '{rate}×',
     previewHint:
       'Önizleme sahte aboneliklerle büyür. Yayında ise bitkin kanalına gelen abonelik, yenileme ve hediye aboneliklerle büyür.',
     widgetUrlTip:

--- a/apps/extensions/src/lib/sub-sprout-url.test.ts
+++ b/apps/extensions/src/lib/sub-sprout-url.test.ts
@@ -72,6 +72,15 @@ describe('buildSubSproutPreviewUrl', () => {
       }),
     ).toBe(`${WIDGET}?variety=cactus&countfx=0&simulate=1`);
   });
+
+  it('adds simspeed only when the preview is sped up', () => {
+    expect(buildSubSproutPreviewUrl(ORIGIN, DEFAULT_SUB_SPROUT_SETTINGS, 1)).toBe(
+      `${WIDGET}?simulate=1`,
+    );
+    expect(buildSubSproutPreviewUrl(ORIGIN, DEFAULT_SUB_SPROUT_SETTINGS, 5)).toBe(
+      `${WIDGET}?simulate=1&simspeed=5`,
+    );
+  });
 });
 
 describe('parseSubSproutUrl', () => {

--- a/apps/extensions/src/lib/sub-sprout-url.ts
+++ b/apps/extensions/src/lib/sub-sprout-url.ts
@@ -63,10 +63,15 @@ export function buildSubSproutUrl(
 
 // simulate=auto stops once the channel's chat connects, leaving the plant at stage 0 with no
 // setting visible. simulate=1 never connects to chat, so the channel is left out and the
-// preview keeps growing.
-export function buildSubSproutPreviewUrl(origin: string, settings: SubSproutSettings): string {
+// preview keeps growing. speed fast-forwards the simulated subs; 1 leaves the param out.
+export function buildSubSproutPreviewUrl(
+  origin: string,
+  settings: SubSproutSettings,
+  speed = 1,
+): string {
   const params = buildSubSproutParams(settings, '', '');
   params.set('simulate', '1');
+  if (speed !== 1) params.set('simspeed', String(speed));
   return `${origin}${WIDGET_PATH}?${params.toString()}`;
 }
 

--- a/apps/extensions/src/routes/widgets/sub-sprout-widget.tsx
+++ b/apps/extensions/src/routes/widgets/sub-sprout-widget.tsx
@@ -51,6 +51,7 @@ const searchSchema = z.object({
     .optional()
     .transform(v => (v === undefined ? undefined : parseSimulateFlag(v)))
     .catch(false),
+  simspeed: z.coerce.number().min(1).max(20).optional().catch(undefined),
 });
 
 export const Route = createFileRoute("/widgets/sub-sprout-widget")({
@@ -88,6 +89,7 @@ function RouteComponent() {
     countfx,
     potlabel,
     simulate,
+    simspeed,
   } = Route.useSearch();
   const { kickId } = Route.useLoaderData();
 
@@ -112,6 +114,7 @@ function RouteComponent() {
         countFx={countfx}
         potLabel={potlabel}
         simulate={simulate}
+        simSpeed={simspeed}
       />
     </div>
   );

--- a/apps/extensions/src/routes/{-$locale}/setup/sub-growing-plant.tsx
+++ b/apps/extensions/src/routes/{-$locale}/setup/sub-growing-plant.tsx
@@ -5,6 +5,7 @@ import { CopyUrlField } from '#/components/copy-url-field';
 import { PreviewFrame } from '#/components/preview-frame';
 import { SetupShell } from '#/components/setup-shell';
 import { FieldLabel } from '#/components/ui/field-label';
+import { RangeField } from '#/components/ui/range-field';
 import { SegmentedControl, type SegmentedOption } from '#/components/ui/segmented-control';
 import { Select, type SelectOption } from '#/components/ui/select';
 import { SettingsGroup } from '#/components/ui/settings-group';
@@ -43,6 +44,9 @@ const WIDGET = getWidget('sub-sprout');
 // sourceSize is only null for tools; the fallback just satisfies the type.
 const CANVAS = WIDGET.sourceSize ?? { width: 800, height: 600 };
 
+// Preview only. At 1x a plant takes 10-20 s to grow through; 10x shows a whole cycle in ~2 s.
+const PREVIEW_SPEEDS = [1, 2, 3, 5, 10];
+
 const FAQ: FaqEntry[] = [
   ['subSprout.faq1Q', 'subSprout.faq1A'],
   ['subSprout.faq2Q', 'subSprout.faq2A'],
@@ -53,6 +57,7 @@ function SubSproutSetup() {
   const [twitchChannel, setTwitchChannel] = useState('');
   const [kickChannel, setKickChannel] = useState('');
   const [settings, setSettings] = useState(DEFAULT_SUB_SPROUT_SETTINGS);
+  const [previewSpeedIndex, setPreviewSpeedIndex] = useState(0);
   const [mounted, setMounted] = useState(false);
   const id = useId();
 
@@ -66,7 +71,9 @@ function SubSproutSetup() {
   // Gated on mount so the prerendered input and the first client render agree.
   const origin = mounted ? window.location.origin : '';
   const widgetUrl = mounted ? buildSubSproutUrl(origin, settings, twitchChannel, kickChannel) : '';
-  const previewUrl = mounted ? buildSubSproutPreviewUrl(origin, settings) : '';
+  const previewUrl = mounted
+    ? buildSubSproutPreviewUrl(origin, settings, PREVIEW_SPEEDS[previewSpeedIndex])
+    : '';
 
   const applyWidgetUrl = (text: string) => {
     const parsed = parseSubSproutUrl(text);
@@ -172,6 +179,7 @@ function SubSproutSetup() {
       title={t('subSprout.title')}
       settings={settingsPanel}
       previewTitle={t('subSprout.previewTitle')}
+      previewTip={t('subSprout.previewHint')}
       previewAspect={CANVAS.width / CANVAS.height}
       preview={
         <PreviewFrame
@@ -182,7 +190,17 @@ function SubSproutSetup() {
         />
       }
       previewFooter={
-        <p className="text-xs leading-relaxed text-zinc-500">{t('subSprout.previewHint')}</p>
+        <RangeField
+          layout="inline"
+          label={t('subSprout.previewSpeed')}
+          tip={t('chatWidget.previewSpeedHint')}
+          min={0}
+          max={PREVIEW_SPEEDS.length - 1}
+          value={previewSpeedIndex}
+          onChange={(value) => setPreviewSpeedIndex(Number(value))}
+          format={(index) => t('subSprout.previewSpeedValue', { rate: PREVIEW_SPEEDS[index] })}
+          readoutClassName="w-10"
+        />
       }
       urlField={
         <CopyUrlField

--- a/apps/extensions/src/test/pages/sub-sprout-setup.test.tsx
+++ b/apps/extensions/src/test/pages/sub-sprout-setup.test.tsx
@@ -1,11 +1,11 @@
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import {
   buildSubSproutUrl,
   DEFAULT_SUB_SPROUT_SETTINGS,
   type SubSproutSettings,
 } from '#/lib/sub-sprout-url';
-import { combobox, en, pickOption, segment, textbox, toggle } from '#/test/queries';
+import { combobox, en, pickOption, segment, slider, textbox, toggle } from '#/test/queries';
 import { renderRoute, setupUser } from '#/test/render';
 
 const PAGE = '/setup/sub-growing-plant';
@@ -81,6 +81,18 @@ describe('Sub Sprout setup', () => {
     await pickOption(user, en('subSprout.plantVariety'), en('plants.rose'));
     expect(water().disabled).toBe(false);
     expect(potLabel().disabled).toBe(false);
+  });
+
+  it('speeds up only the preview, never the widget URL', async () => {
+    const user = setupUser();
+    await renderRoute(PAGE);
+    await user.type(twitchField(), 'streamer');
+    const before = urlField().value;
+
+    fireEvent.change(slider(en('subSprout.previewSpeed')), { target: { value: '3' } });
+
+    expect(screen.getByText(en('subSprout.previewSpeedValue', { rate: 5 }))).toBeTruthy();
+    expect(urlField().value).toBe(before);
   });
 
   it('disables the channel field of the platform that is not picked', async () => {


### PR DESCRIPTION
> **Stacked on #703.** This branch starts from the head of #703 (`0c5bb45`), so until that is merged this PR also shows its commits. The only new commit is `84f585d`. Please merge #703 first; I'll rebase this onto `dev` after that.

The Sub Sprout setup preview grows the plant with simulated subs at the overlay's real pace, so seeing a plant through all of its stages (or the next plant with In Order / Random) meant waiting 10-20 seconds after every change. The Chat Box preview already has a speed slider for the same reason; this adds one here.

**Setup page**
- A **Preview Growth Speed** slider under the preview: 1×, 2×, 3×, 5×, 10×. It only changes the preview's URL; the widget URL for OBS stays the same.
- The "grows with simulated subs" note moves from under the preview into the "?" tip next to the preview title, the same place the Chat Box keeps its hint.

**Overlay**
- `/widgets/sub-sprout-widget` reads a new `simspeed` param (1-20, anything else is ignored). It scales the growth step, the sub count and watering effects, and the gap between simulated subs together, so the preview plays like a fast-forward instead of cutting effects off.
- It only applies while simulating. Real subs always run at 1×, even if `simspeed` ends up in an OBS URL. URLs without it behave exactly as before.

**Testing**
- `tsc --noEmit`: clean. `vitest`: 595 passed, including new tests for the preview URL (`simspeed` only when sped up) and for the slider leaving the widget URL unchanged.
- Production build + `vite preview`: at 10× the Classic Sprout runs through all of its stages in ~2 s; Rose with rain and the pot label at 3× plays every effect at the faster pace. At 1× the iframe URL has no `simspeed`.
